### PR TITLE
remove gfortran dependency when running on Mac

### DIFF
--- a/knowhere/CMakeLists.txt
+++ b/knowhere/CMakeLists.txt
@@ -196,7 +196,7 @@ if (MACOS)
         )
     endif ()
 
-    target_link_libraries(knowhere gfortran pthread index_log knowhere_utils)
+    target_link_libraries(knowhere pthread index_log knowhere_utils)
     set(INDEX_INCLUDE_DIRS ${INDEX_SOURCE_DIR}/knowhere)
 endif()
 


### PR DESCRIPTION
Signed-off-by: yun.zhang <yun.zhang@zilliz.com>