### PR TITLE
Add interface for Disk Index's file operator

### DIFF
--- a/knowhere/common/FileOperator.h
+++ b/knowhere/common/FileOperator.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <optional>
+
+namespace knowhere {
+
+class FileOperator {
+    /**
+     * @brief Load a file to the local disk, so we can use stl lib to operate it.
+     *
+     * @param filename
+     * @return false if any error, or return true.
+     */
+    virtual bool
+    load_file(const std::string& filename) noexcept;
+
+    /**
+     * @brief Check if a file exists.
+     *
+     * @param filename
+     * @return std::nullopt if any error, or return if the file exists.
+     */
+    virtual std::optional<bool>
+    is_existed(const std::string& filename) noexcept;
+
+    /**
+     * @brief Create a file.
+     *
+     * @param filename
+     * @return false if any error, or return true.
+     */
+    virtual bool
+    create_file(const std::string& filename) noexcept;
+
+    /**
+     * @brief Delete a file.
+     *
+     * @param filename
+     * @return false if any error, or return true.
+     */
+    virtual bool
+    delete_file(const std::string& filename) noexcept;
+
+    /**
+     * @brief Rename a file.
+     *
+     * @param filename
+     * @return false if any error, or return true.
+     */
+    virtual bool
+    rename_file(const std::string& from_name, const std::string& to_name) noexcept;
+};
+
+}  // namespace knowhere


### PR DESCRIPTION
We planed to do two steps for this `Fileoperators`:
1. Manipulate files in a coarse granularity, which means just load/create/delete file to ensure file is on the disk. (This can not handle if the disk is too small to fit the file size).
2. Do it in a fine granularity. We can do read/write/seek there.

This is for step 1.

We hope that act as a lib, knowhere will not throw any exception in the future. So I marked all function with `noexcept`. Plz follow the function description to return if any error, and log it in the implementation code.