### PR TITLE
Add interface for Disk Index's file operator

### DIFF
--- a/knowhere/common/FileManager.h
+++ b/knowhere/common/FileManager.h
@@ -1,0 +1,65 @@
+// Copyright (C) 2019-2020 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under the License.
+
+#pragma once
+
+#include <optional>
+#include <string>
+
+namespace knowhere {
+
+/**
+ * @brief This FileManager is used to manage file, including its replication, backup, ect.
+ * It will act as a cloud-like client, and Knowhere need to call load/add to better support
+ * distribution of the whole service.
+ *
+ * (TODO) we need support finer granularity file operator (read/write),
+ * so Knowhere doesn't need to offer any help for service in the future .
+ */
+class FileManager {
+    /**
+     * @brief Load a file to the local disk, so we can use stl lib to operate it.
+     *
+     * @param filename
+     * @return false if any error, or return true.
+     */
+    virtual bool
+    LoadFile(const std::string& filename) noexcept;
+
+    /**
+     * @brief Add file to FileManager to manipulate it.
+     *
+     * @param filename
+     * @return false if any error, or return true.
+     */
+    virtual bool
+    AddFile(const std::string& filename) noexcept;
+
+    /**
+     * @brief Check if a file exists.
+     *
+     * @param filename
+     * @return std::nullopt if any error, or return if the file exists.
+     */
+    virtual std::optional<bool>
+    IsExisted(const std::string& filename) noexcept;
+
+    /**
+     * @brief Delete a file from FileManager.
+     *
+     * @param filename
+     * @return false if any error, or return true.
+     */
+    virtual bool
+    RemoveFile(const std::string& filename) noexcept;
+};
+
+}  // namespace knowhere


### PR DESCRIPTION
Signed-off-by: liliu-z <li.liu@zilliz.com>

issue: #253 

We planed to do two steps for this Fileoperators:

1. Manipulate files in a coarse granularity, which means just load/create/delete file to ensure file is on the disk. (This can not handle if the disk is too small to fit the file size).
2. Do it in a fine granularity. We can do read/write/seek there.

This is for step 1.

We hope that act as a lib, knowhere will not throw any exception in the future. So I marked all function with noexcept. Plz follow the function description to return if any error, and log it in the implementation code.