### PR TITLE
Support Filemanager in DiskANN code

### DIFF
--- a/knowhere/common/FileManager.h
+++ b/knowhere/common/FileManager.h
@@ -25,6 +25,7 @@ namespace knowhere {
  * so Knowhere doesn't need to offer any help for service in the future .
  */
 class FileManager {
+ public:
     /**
      * @brief Load a file to the local disk, so we can use stl lib to operate it.
      *

--- a/knowhere/index/vector_index/IndexDiskANN.h
+++ b/knowhere/index/vector_index/IndexDiskANN.h
@@ -90,6 +90,12 @@ class IndexDiskANN : public VecIndex {
     }
 
  private:
+    bool
+    LoadFile(const std::string& filename);
+
+    bool
+    AddFile(const std::string& filename);
+
     std::string index_prefix_;
 
     diskann::Metric metric_;

--- a/thirdparty/DiskANN/include/pq_table.h
+++ b/thirdparty/DiskANN/include/pq_table.h
@@ -45,11 +45,12 @@ namespace diskann {
 #else
     void load_pq_centroid_bin(const char* pq_table_file, size_t num_chunks) {
 #endif
-        std::string rearrangement_file = std::string(pq_table_file) +
-                                         "_rearrangement_perm.bin";
+        std::string rearrangement_file =
+            get_pq_rearrangement_perm_filename(std::string(pq_table_file));
     std::string chunk_offset_file =
-        std::string(pq_table_file) + "_chunk_offsets.bin";
-    std::string centroid_file = std::string(pq_table_file) + "_centroid.bin";
+        get_pq_chunk_offsets_filename(std::string(pq_table_file));
+    std::string centroid_file = 
+        get_pq_centroid_filename(std::string(pq_table_file));
 
     // bin structure: [256][ndims][ndims(float)]
     uint64_t numr, numc;

--- a/thirdparty/DiskANN/include/utils.h
+++ b/thirdparty/DiskANN/include/utils.h
@@ -855,6 +855,51 @@ namespace diskann {
 
   template<typename T>
   Distance<T>* get_distance_function(Metric m);
+
+  inline std::string get_pq_pivots_filename(const std::string& prefix) {
+    return prefix + "_pq_pivots.bin";
+  }
+
+  inline std::string get_pq_rearrangement_perm_filename(
+      const std::string& pq_pivots_filename) {
+    return pq_pivots_filename + "_rearrangement_perm.bin";
+  }
+
+  inline std::string get_pq_chunk_offsets_filename(
+      const std::string& pq_pivots_filename) {
+    return pq_pivots_filename + "_chunk_offsets.bin";
+  }
+
+  inline std::string get_pq_centroid_filename(const std::string& pq_pivots_filename) {
+    return pq_pivots_filename + "_centroid.bin";
+  }
+
+  inline std::string get_pq_compressed_filename(const std::string& prefix) {
+    return prefix + "_pq_compressed.bin";
+  }
+
+  inline std::string get_disk_index_filename(const std::string& prefix) {
+    return prefix + "_disk.index";
+  }
+
+  inline std::string get_disk_index_medoids_filename(
+      const std::string& disk_index_filename) {
+    return disk_index_filename + "_medoids.bin";
+  }
+
+  inline std::string get_disk_index_centroids_filename(
+      const std::string& disk_index_filename) {
+    return disk_index_filename + "_centroids.bin";
+  }
+
+  inline std::string get_sample_data_filename(const std::string& prefix) {
+    return prefix + "_sample_data.bin";
+  }
+
+  inline std::string get_disk_index_max_base_norm_file(
+      const std::string& disk_index_filename) {
+    return disk_index_filename + "_max_base_norm.bin";
+  }
 };  // namespace diskann
 
 struct PivotContainer {

--- a/thirdparty/DiskANN/src/aux_utils.cpp
+++ b/thirdparty/DiskANN/src/aux_utils.cpp
@@ -970,14 +970,16 @@ namespace diskann {
     std::string base_file(dataFilePath);
     std::string data_file_to_use = base_file;
     std::string index_prefix_path(indexFilePath);
-    std::string pq_pivots_path = index_prefix_path + "_pq_pivots.bin";
+    std::string pq_pivots_path = get_pq_pivots_filename(index_prefix_path);
     std::string pq_compressed_vectors_path =
-        index_prefix_path + "_pq_compressed.bin";
+        get_pq_compressed_filename(index_prefix_path);
     std::string mem_index_path = index_prefix_path + "_mem.index";
-    std::string disk_index_path = index_prefix_path + "_disk.index";
-    std::string medoids_path = disk_index_path + "_medoids.bin";
-    std::string centroids_path = disk_index_path + "_centroids.bin";
-    std::string sample_base_prefix = index_prefix_path + "_sample";
+    std::string disk_index_path = get_disk_index_filename(index_prefix_path);
+    std::string medoids_path = 
+        get_disk_index_medoids_filename(disk_index_path);
+    std::string centroids_path = 
+        get_disk_index_centroids_filename(disk_index_path);
+    std::string sample_data_file = get_sample_data_filename(index_prefix_path);
     // optional, used if disk index file must store pq data
     std::string disk_pq_pivots_path =
         index_prefix_path + "_disk.index_pq_pivots.bin";
@@ -998,7 +1000,8 @@ namespace diskann {
       data_file_to_use = prepped_base;
       float max_norm_of_base =
           diskann::prepare_base_for_inner_products<T>(base_file, prepped_base);
-      std::string norm_file = disk_index_path + "_max_base_norm.bin";
+      std::string norm_file = 
+          get_disk_index_max_base_norm_file(disk_index_path);
       diskann::save_bin<float>(norm_file, &max_norm_of_base, 1, 1);
     }
 
@@ -1121,7 +1124,7 @@ namespace diskann {
                                    ? MAX_SAMPLE_POINTS_FOR_WARMUP
                                    : ten_percent_points;
     double sample_sampling_rate = num_sample_points / points_num;
-    gen_random_slice<T>(data_file_to_use.c_str(), sample_base_prefix,
+    gen_random_slice<T>(data_file_to_use.c_str(), sample_data_file,
                         sample_sampling_rate);
 
     std::remove(mem_index_path.c_str());

--- a/thirdparty/DiskANN/src/pq_flash_index.cpp
+++ b/thirdparty/DiskANN/src/pq_flash_index.cpp
@@ -544,14 +544,16 @@ namespace diskann {
   template<typename T>
   int PQFlashIndex<T>::load(uint32_t num_threads, const char *index_prefix) {
 #endif
-    std::string pq_table_bin = std::string(index_prefix) + "_pq_pivots.bin";
+    std::string pq_table_bin = 
+        get_pq_pivots_filename(std::string(index_prefix));
     std::string pq_compressed_vectors =
-        std::string(index_prefix) + "_pq_compressed.bin";
+        get_pq_compressed_filename(std::string(index_prefix));
     std::string disk_index_file =
-        std::string(index_prefix) + "_disk.index";
-    std::string medoids_file = std::string(disk_index_file) + "_medoids.bin";
+        get_disk_index_filename(std::string(index_prefix));
+    std::string medoids_file = 
+        get_disk_index_medoids_filename(std::string(disk_index_file));
     std::string centroids_file =
-        std::string(disk_index_file) + "_centroids.bin";
+        get_disk_index_centroids_filename(std::string(disk_index_file));
 
     size_t pq_file_dim, pq_file_num_centroids;
 #ifdef EXEC_ENV_OLS
@@ -782,7 +784,8 @@ namespace diskann {
       use_medoids_data_as_centroids();
     }
 
-    std::string norm_file = std::string(disk_index_file) + "_max_base_norm.bin";
+    std::string norm_file = 
+        get_disk_index_max_base_norm_file(std::string(disk_index_file));
 
     if (file_exists(norm_file) && metric == diskann::Metric::INNER_PRODUCT) {
       _u64   dumr, dumc;

--- a/thirdparty/DiskANN/tests/utils/gen_random_slice.cpp
+++ b/thirdparty/DiskANN/tests/utils/gen_random_slice.cpp
@@ -25,7 +25,7 @@ int aux_main(char** argv) {
   std::string base_file(argv[2]);
   std::string output_prefix(argv[3]);
   float       sampling_rate = (float) (std::atof(argv[4]));
-  gen_random_slice<T>(base_file, output_prefix, sampling_rate);
+  gen_random_slice<T>(base_file, output_prefix + "_data.bin", sampling_rate);
   return 0;
 }
 


### PR DESCRIPTION
Signed-off-by: liliu-z <li.liu@zilliz.com>

## General
This PR did two things:
1. We supported `FileManager` in `DiskANN`.
2. We collected all filenames that need to be managed by the `FileManager` and wrote getter inside `DiskANN` source code to get them. Since `DiskANN` now manually form the filename whenever it need them, which is super error-prone.

## FileManager
This is the first step of the `FileManager`. In the plan, we have two steps in total:
1. `FileManager` will help in file granularity. We call `AddFile` to register file to the `FileManager` and call `LoadFile` to ensure `FileManager` prepare it well to use. This way is clean and easy to implement. The drawbacks are:
  a. `Knowhere` should know the existence of a remote platform, so it needs to proactively call method to prepare the files.
  b.  If the file is too large to fit the Disk, this method cannot work.
2. In this step we plan to solve the problems mentioned before. We need to use `FileManager` as a `ifstream` + `ofstream`, so it can support finer granularity. 