### PR TITLE
Reduce the memory usage of thread data's coord_scratch

### DIFF
--- a/thirdparty/DiskANN/include/pq_flash_index.h
+++ b/thirdparty/DiskANN/include/pq_flash_index.h
@@ -21,7 +21,6 @@
 #include "windows_customizations.h"
 
 #define MAX_GRAPH_DEGREE 512
-#define MAX_N_CMPS 16384
 #define SECTOR_LEN (_u64) 4096
 #define MAX_N_SECTOR_READS 128
 #define MAX_PQ_CHUNKS 256
@@ -31,8 +30,7 @@
 namespace diskann {
   template<typename T>
   struct QueryScratch {
-    T *  coord_scratch = nullptr;  // MUST BE AT LEAST [MAX_N_CMPS * data_dim]
-    _u64 coord_idx = 0;            // index of next [data_dim] scratch to use
+    T *  coord_scratch = nullptr;  // MUST BE AT LEAST [sizeof(T) * data_dim]
 
     char *sector_scratch =
         nullptr;          // MUST BE AT LEAST [MAX_N_SECTOR_READS * SECTOR_LEN]
@@ -50,7 +48,6 @@ namespace diskann {
     tsl::robin_set<_u64> *visited = nullptr;
 
     void reset() {
-      coord_idx = 0;
       sector_idx = 0;
       visited->clear();  // does not deallocate memory.
     }


### PR DESCRIPTION
**There are two main reasons for optimizing coord_scratch:**
1.  DiskANN applies for a large amount of memory space for coord_scratch.  But coord_scratch only uses a small amount of space to store calculated data；
2. DiskANN uses the wrong indexing mode (i * dim), the correct one is (i* dim * sizeof(T)). Therefore, it is easy to cause out-of-bounds access.

**Therefore, this optimization achieves the following two points:**
1.  Allocate as much memory space to coord_scratch as the search uses;
2. The data to be calculated is directly copied to the starting position of 

**The following is the experimental analysis of sift1M:**

-    Experiment environment:  AWS m6id.2xlarge;

-    Preparation :  No cache, Threads number = 8;

<img width="869" alt="image" src="https://user-images.githubusercontent.com/39671710/181669730-77e94171-854b-4fea-96ab-0c6b2b7dd4f7.png">

After optimization, DiskANN can reduce a lot of thread data memory space. It can be observed that the memory footprint of thread data is negligible compared to the PQ compression code.



