### PR TITLE
Fix: query vector copy out of bounds when using InnnerProduct

### DIFF
--- a/thirdparty/DiskANN/src/aux_utils.cpp
+++ b/thirdparty/DiskANN/src/aux_utils.cpp
@@ -1124,7 +1124,7 @@ namespace diskann {
                                    ? MAX_SAMPLE_POINTS_FOR_WARMUP
                                    : ten_percent_points;
     double sample_sampling_rate = num_sample_points / points_num;
-    gen_random_slice<T>(data_file_to_use.c_str(), sample_data_file,
+    gen_random_slice<T>(base_file.c_str(), sample_data_file,
                         sample_sampling_rate);
 
     if (compareMetric == diskann::Metric::INNER_PRODUCT) {


### PR DESCRIPTION
Signed-off-by: wusonglin <wusonglin@tongji.edu.cn>

issue: #253 

diskann uses norm L2 to replace InnerProduct when using SSD index. It adds an extra dim at the end, this would cause a  array out of bounds issue.
<img width="349" alt="image" src="https://user-images.githubusercontent.com/61929733/181734213-503b6d37-7384-4b50-b837-b4b596558750.png">

