### PR TITLE
Relax Diskann's dimension check

### DIFF
--- a/knowhere/index/vector_index/IndexDiskANN.cpp
+++ b/knowhere/index/vector_index/IndexDiskANN.cpp
@@ -52,9 +52,6 @@ IndexDiskANN<T>::IndexDiskANN(std::string index_prefix, MetricType metric_type,
 }
 
 namespace {
-static constexpr size_t kMinDim = 128;
-static constexpr size_t kMaxDim = 756;
-
 void
 CheckPreparation(bool is_prepared) {
     if (!is_prepared) {
@@ -141,20 +138,12 @@ CheckNodeLength(const uint32_t degree, const size_t dim) {
     }
 }
 
-void
-CheckDimRange(const size_t dim) {
-    if (dim > kMaxDim || dim < kMinDim) {
-        KNOWHERE_THROW_FORMAT("Data dim %ld is not in range [%ld, %ld]", dim, kMinDim, kMinDim);
-    }
-}
-
 template <typename T>
 void
 CheckBuildParams(const DiskANNBuildConfig& build_conf) {
     size_t num, dim;
     diskann::get_bin_metadata(build_conf.data_path, num, dim);
 
-    CheckDimRange(dim);
     CheckFileSize<T>(build_conf.data_path, num, dim);
     CheckNodeLength<T>(build_conf.max_degree, dim);
 }


### PR DESCRIPTION
Signed-off-by: cqy123456 <yaya645@126.com>
The dimension of diskann is no longer limited to [128, 756], it only depends on whether the node size is smaller than a sector.