### PR TITLE
Remove useless file in DiskANN

### DIFF
--- a/thirdparty/DiskANN/include/index.h
+++ b/thirdparty/DiskANN/include/index.h
@@ -112,7 +112,8 @@ namespace diskann {
 
     // checks if data is consolidated, saves graph, metadata and associated
     // tags.
-    DISKANN_DLLEXPORT void save(const char *filename);
+    DISKANN_DLLEXPORT void save(const char *filename,
+                                const bool  disk_index = false);
     DISKANN_DLLEXPORT _u64 save_graph(std::string filename);
     DISKANN_DLLEXPORT _u64 save_data(std::string filename);
     DISKANN_DLLEXPORT _u64 save_tags(std::string filename);

--- a/thirdparty/DiskANN/src/aux_utils.cpp
+++ b/thirdparty/DiskANN/src/aux_utils.cpp
@@ -574,7 +574,7 @@ namespace diskann {
               compareMetric, base_dim, base_num, false, false));
       _pvamanaIndex->build(base_file.c_str(), base_num, paras);
 
-      _pvamanaIndex->save(mem_index_path.c_str());
+      _pvamanaIndex->save(mem_index_path.c_str(), true);
       std::remove(medoids_file.c_str());
       std::remove(centroids_file.c_str());
       return 0;
@@ -1127,6 +1127,9 @@ namespace diskann {
     gen_random_slice<T>(data_file_to_use.c_str(), sample_data_file,
                         sample_sampling_rate);
 
+    if (compareMetric == diskann::Metric::INNER_PRODUCT) {
+      std::remove(data_file_to_use.c_str());
+    }
     std::remove(mem_index_path.c_str());
     if (use_disk_pq)
       std::remove(disk_pq_compressed_vectors_path.c_str());

--- a/thirdparty/DiskANN/src/index.cpp
+++ b/thirdparty/DiskANN/src/index.cpp
@@ -439,7 +439,7 @@ namespace diskann {
   }
 
   template<typename T, typename TagT>
-  void Index<T, TagT>::save(const char *filename) {
+  void Index<T, TagT>::save(const char *filename, const bool disk_index) {
     // first check if no thread is inserting
     auto start = std::chrono::high_resolution_clock::now();
     std::unique_lock<std::shared_timed_mutex> lock(_update_lock);
@@ -449,22 +449,25 @@ namespace diskann {
     compact_frozen_point();
     if (!_save_as_one_file) {
       std::string graph_file = std::string(filename);
-      std::string tags_file = std::string(filename) + ".tags";
-      std::string data_file = std::string(filename) + ".data";
-      std::string delete_list_file = std::string(filename) + ".del";
-
-      // Because the save_* functions use append mode, ensure that
-      // the files are deleted before save. Ideally, we should check
-      // the error code for delete_file, but will ignore now because
-      // delete should succeed if save will succeed.
       delete_file(graph_file);
       save_graph(graph_file);
-      delete_file(data_file);
-      save_data(data_file);
-      delete_file(tags_file);
-      save_tags(tags_file);
-      delete_file(delete_list_file);
-      save_delete_list(delete_list_file);
+      if (!disk_index) {
+        std::string tags_file = std::string(filename) + ".tags";
+        std::string data_file = std::string(filename) + ".data";
+        std::string delete_list_file = std::string(filename) + ".del";
+
+        // Because the save_* functions use append mode, ensure that
+        // the files are deleted before save. Ideally, we should check
+        // the error code for delete_file, but will ignore now because
+        // delete should succeed if save will succeed.
+
+        delete_file(data_file);
+        save_data(data_file);
+        delete_file(tags_file);
+        save_tags(tags_file);
+        delete_file(delete_list_file);
+        save_delete_list(delete_list_file);
+      }
     } else {
         diskann::cout<<"Save index in a single file currently not supported. Not saving the index." << std::endl;
     }


### PR DESCRIPTION
Signed-off-by: liliu-z <li.liu@zilliz.com>

Removed two files:
`_mem.index.data`: this is used for memory based DiskANN.
`_prepped_base.bin`: this is used for IP build, no need for search