### PR TITLE
Fix error message in DiskANN

### DIFF
--- a/thirdparty/DiskANN/src/linux_aligned_file_reader.cpp
+++ b/thirdparty/DiskANN/src/linux_aligned_file_reader.cpp
@@ -135,10 +135,10 @@ void LinuxAlignedFileReader::register_thread() {
   int          ret = io_setup(MAX_EVENTS, &ctx);
   if (ret != 0) {
     lk.unlock();
-    assert(errno != EAGAIN);
-    assert(errno != ENOMEM);
-    std::cerr << "io_setup() failed; returned " << ret << ", errno=" << errno
-              << ":" << ::strerror(errno) << std::endl;
+    assert(-ret != EAGAIN);
+    assert(-ret != ENOMEM);
+    std::cerr << "io_setup() failed; returned " << ret << ", errno=" << -ret
+              << ":" << ::strerror(-ret) << std::endl;
   } else {
     diskann::cout << "allocating ctx: " << ctx << " to thread-id:" << my_id
                   << std::endl;


### PR DESCRIPTION
Signed-off-by: zh Wang <zihao.wang@zilliz.com>

issue: #253 

The libaio wrapper doesn't set errno but instead returns the negation of error number to indicating the error.