### PR TITLE
Clean DiskANN log and fix wrong info in output

### DIFF
--- a/.github/workflows/ut.yaml
+++ b/.github/workflows/ut.yaml
@@ -50,7 +50,7 @@ jobs:
           then
             diskann_opt=-d
           fi
-          ./build.sh $diskann_opt -t Release -u
+          ./build.sh $diskann_opt -u
           if [[ -f "output/unittest/faiss_test" ]]; then
             ./output/unittest/faiss_test
           fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,6 +128,9 @@ else ()
     append_flags( CUDA_NVCC_FLAGS FLAGS "-O0" "-g" )
 endif ()
 
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DDEBUG")
+set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -DELPP_DISABLE_DEBUG_LOGS")
+
 append_flags( CMAKE_CXX_FLAGS
               FLAGS
                     "-fPIC"

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -156,7 +156,7 @@ macro(build_diskann)
             "-DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}"
             "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}"
             "-DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}"
-            "-DCMAKE_CXX_FLAGS= -O3 -fPIC -DELPP_THREAD_SAFE -fopenmp -rdynamic -fpermissive -I ${KNOWHERE_SOURCE_DIR}"
+            "-DKNOWHERE_SOURCE_DIR=${KNOWHERE_SOURCE_DIR}"
             )
     message( STATUS "Building DISKANN with configure args -${DISKANN_CMAKE_ARGS}" )
     set( DISKANN_BUILD_DIR "${DISKANN_SOURCE_DIR}/build")
@@ -170,8 +170,7 @@ macro(build_diskann)
         INSTALL_COMMAND
         ${MAKE} install
         BUILD_BYPRODUCTS
-        ${DISKANN_STATIC_LIB}
-        BUILD_ALWAYS 1)
+        ${DISKANN_STATIC_LIB} )
 
         add_library( diskann STATIC IMPORTED )
        

--- a/thirdparty/DiskANN/CMakeLists.txt
+++ b/thirdparty/DiskANN/CMakeLists.txt
@@ -229,10 +229,15 @@ else()
 	set(ENV{TCMALLOC_LARGE_ALLOC_REPORT_THRESHOLD} 500000000000)
     #	set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g -DDEBUG -O0 -fsanitize=address -fsanitize=leak -fsanitize=undefined")
     set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g -DDEBUG -Wall -Wextra")
-	set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -Ofast -DNDEBUG -march=native -mtune=native -ftree-vectorize")
+	set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -Ofast -DELPP_DISABLE_DEBUG_LOGS -DNDEBUG -march=native -mtune=native -ftree-vectorize")
 	add_compile_options(-march=native -Wall -fno-builtin-malloc -fno-builtin-calloc -fno-builtin-realloc -fno-builtin-free -fopenmp -fopenmp-simd -funroll-loops -Wfatal-errors -DUSE_AVX2)
 endif()
 
+include_directories( ${KNOWHERE_SOURCE_DIR} )
+include_directories( ${KNOWHERE_SOURCE_DIR}/thirdparty/ )
+add_definitions( -DAUTO_INITIALIZE_EASYLOGGINGPP )
+
 add_subdirectory(src)
-add_subdirectory(tests)
-add_subdirectory(tests/utils)
+# Don't need executable files
+# add_subdirectory(tests)
+# add_subdirectory(tests/utils)

--- a/thirdparty/DiskANN/include/cached_io.h
+++ b/thirdparty/DiskANN/include/cached_io.h
@@ -38,8 +38,8 @@ class cached_ifstream {
       this->cache_size = cacheSize;
       cache_buf = new char[cacheSize];
       reader.read(cache_buf, cacheSize);
-      diskann::cout << "Opened: " << filename.c_str() << ", size: " << fsize
-                    << ", cache_size: " << cacheSize << std::endl;
+      LOG(DEBUG) << "Opened: " << filename.c_str() << ", size: " << fsize
+                    << ", cache_size: " << cacheSize;
     } catch (std::system_error& e) {
       throw diskann::FileException(filename, e, __FUNCSIG__, __FILE__,
                                    __LINE__);
@@ -113,8 +113,8 @@ class cached_ofstream {
       assert(writer.is_open());
       assert(cache_size > 0);
       cache_buf = new char[cache_size];
-      diskann::cout << "Opened: " << filename.c_str()
-                    << ", cache_size: " << cache_size << std::endl;
+      LOG(DEBUG) << "Opened: " << filename.c_str()
+                 << ", cache_size: " << cache_size;
     } catch (std::system_error& e) {
       throw diskann::FileException(filename, e, __FUNCSIG__, __FILE__,
                                    __LINE__);
@@ -129,7 +129,7 @@ class cached_ofstream {
 
     delete[] cache_buf;
     writer.close();
-    diskann::cout << "Finished writing " << fsize << "B" << std::endl;
+    LOG(DEBUG) << "Finished writing " << fsize << "B";
   }
 
   size_t get_file_size() {

--- a/thirdparty/DiskANN/include/logger.h
+++ b/thirdparty/DiskANN/include/logger.h
@@ -3,6 +3,7 @@
 
 #include <iostream>
 #include "windows_customizations.h"
+#include "easyloggingpp/easylogging++.h"
 
 namespace diskann {
   DISKANN_DLLEXPORT extern std::basic_ostream<char> cout;

--- a/thirdparty/DiskANN/include/pq_table.h
+++ b/thirdparty/DiskANN/include/pq_table.h
@@ -82,14 +82,13 @@ namespace diskann {
         diskann::load_bin<_u32>(chunk_offset_file, chunk_offsets, numr, numc);
 #endif
       if (numc != 1 || (numr != num_chunks + 1 && num_chunks != 0)) {
-        diskann::cerr << "Error loading chunk offsets file. numc: " << numc
+        LOG(ERROR) << "Error loading chunk offsets file. numc: " << numc
                       << " (should be 1). numr: " << numr << " (should be "
-                      << num_chunks + 1 << ")" << std::endl;
+                      << num_chunks + 1 << ")";
         throw diskann::ANNException("Error loading chunk offsets file", -1,
                                     __FUNCSIG__, __FILE__, __LINE__);
       }
-      std::cout << "PQ data has " << numr - 1 << " bytes per point."
-                << std::endl;
+      LOG(DEBUG) << "PQ data has " << numr - 1 << " bytes per point.";
       this->n_chunks = numr - 1;
 
 #ifdef EXEC_ENV_OLS
@@ -98,7 +97,7 @@ namespace diskann {
         diskann::load_bin<float>(centroid_file, centroid, numr, numc);
 #endif
       if (numc != 1 || numr != ndims_u64) {
-        diskann::cerr << "Error loading centroid file" << std::endl;
+        LOG(ERROR) << "Error loading centroid file";
         throw diskann::ANNException("Error loading centroid file", -1,
                                     __FUNCSIG__, __FILE__, __LINE__);
       }
@@ -116,9 +115,9 @@ namespace diskann {
       std::memset(centroid, 0, ndims * sizeof(float));
     }
 
-    diskann::cout << "PQ Pivots: #ctrs: " << npts_u64
-                  << ", #dims: " << ndims_u64 << ", #chunks: " << n_chunks
-                  << std::endl;
+    LOG(INFO) << "PQ Pivots: #ctrs: " << npts_u64
+              << ", #dims: " << ndims_u64 
+              << ", #chunks: " << n_chunks;
     //      assert((_u64) ndims_u32 == n_chunks * chunk_size);
     // alloc and compute transpose
     tables_T = new float[256 * ndims_u64];

--- a/thirdparty/DiskANN/include/utils.h
+++ b/thirdparty/DiskANN/include/utils.h
@@ -276,7 +276,7 @@ namespace diskann {
     npts = (unsigned) npts_i32;
     dim = (unsigned) dim_i32;
 
-    diskann::cout << "Metadata: #pts = " << npts << ", #dims = " << dim << "..."
+    LOG(DEBUG) << "Metadata: #pts = " << npts << ", #dims = " << dim << "..."
                   << std::endl;
 
     size_t expected_actual_file_size =
@@ -287,7 +287,7 @@ namespace diskann {
              << " while expected size is  " << expected_actual_file_size
              << " npts = " << npts << " dim = " << dim
              << " size of <T>= " << sizeof(T) << std::endl;
-      diskann::cout << stream.str();
+      LOG(ERROR) << stream.str();
       throw diskann::ANNException(stream.str(), -1, __FUNCSIG__, __FILE__,
                                   __LINE__);
     }
@@ -348,8 +348,7 @@ namespace diskann {
     reader.exceptions(std::ifstream::failbit | std::ifstream::badbit);
 
     try {
-      diskann::cout << "Opening bin file " << bin_file.c_str() << "... "
-                    << std::endl;
+      LOG(DEBUG) << "Opening bin file " << bin_file.c_str() << "... ";
       reader.open(bin_file, std::ios::binary | std::ios::ate);
       uint64_t fsize = reader.tellg();
       reader.seekg(0);
@@ -357,7 +356,7 @@ namespace diskann {
     } catch (std::system_error& e) {
       throw FileException(bin_file, e, __FUNCSIG__, __FILE__, __LINE__);
     }
-    diskann::cout << "done." << std::endl;
+    LOG(DEBUG) << "done.";
   }
   // load_bin functions END
 
@@ -365,8 +364,7 @@ namespace diskann {
                             float*& dists, size_t& npts, size_t& dim) {
     _u64            read_blk_size = 64 * 1024 * 1024;
     cached_ifstream reader(bin_file, read_blk_size);
-    diskann::cout << "Reading truthset file " << bin_file.c_str() << " ..."
-                  << std::endl;
+    LOG(DEBUG) << "Reading truthset file " << bin_file.c_str() << " ...";
     size_t actual_file_size = reader.get_file_size();
 
     int npts_i32, dim_i32;
@@ -375,8 +373,7 @@ namespace diskann {
     npts = (unsigned) npts_i32;
     dim = (unsigned) dim_i32;
 
-    diskann::cout << "Metadata: #pts = " << npts << ", #dims = " << dim
-                  << "... " << std::endl;
+    LOG(DEBUG) << "Metadata: #pts = " << npts << ", #dims = " << dim << "... ";
 
     int truthset_type = -1;  // 1 means truthset has ids and distances, 2 means
                              // only ids, -1 is error
@@ -419,8 +416,7 @@ namespace diskann {
       std::vector<std::vector<_u32>>& groundtruth, size_t& npts) {
     _u64            read_blk_size = 64 * 1024 * 1024;
     cached_ifstream reader(bin_file, read_blk_size);
-    diskann::cout << "Reading truthset file " << bin_file.c_str() << "... "
-                  << std::endl;
+    LOG(DEBUG) << "Reading truthset file " << bin_file.c_str() << "... ";
     size_t actual_file_size = reader.get_file_size();
 
     int npts_i32, dim_i32;
@@ -431,8 +427,7 @@ namespace diskann {
     _u32*  ids;
     float* dists;
 
-    diskann::cout << "Metadata: #pts = " << npts << ", #dims = " << dim
-                  << "... " << std::endl;
+    LOG(DEBUG) << "Metadata: #pts = " << npts << ", #dims = " << dim << "... ";
 
     int truthset_type = -1;  // 1 means truthset has ids and distances, 2 means
                              // only ids, -1 is error
@@ -488,8 +483,7 @@ namespace diskann {
                                   _u64&                           gt_num) {
     _u64            read_blk_size = 64 * 1024 * 1024;
     cached_ifstream reader(bin_file, read_blk_size);
-    diskann::cout << "Reading truthset file " << bin_file.c_str() << "... "
-                  << std::flush;
+    LOG(DEBUG) << "Reading truthset file " << bin_file.c_str() << "... ";
     size_t actual_file_size = reader.get_file_size();
 
     int npts_u32, total_u32;
@@ -499,8 +493,8 @@ namespace diskann {
     gt_num = (_u64) npts_u32;
     _u64 total_res = (_u64) total_u32;
 
-    diskann::cout << "Metadata: #pts = " << gt_num
-                  << ", #total_results = " << total_res << "..." << std::endl;
+    LOG(DEBUG) << "Metadata: #pts = " << gt_num << ", #total_results = " 
+               << total_res << "...";
 
     size_t expected_file_size =
         2 * sizeof(_u32) + gt_num * sizeof(_u32) + total_res * sizeof(_u32);
@@ -559,19 +553,19 @@ namespace diskann {
   inline uint64_t save_bin(const std::string& filename, T* data, size_t npts,
                            size_t ndims) {
     std::ofstream writer(filename, std::ios::binary | std::ios::out);
-    diskann::cout << "Writing bin: " << filename.c_str() << std::endl;
+    LOG(DEBUG) << "Writing bin: " << filename.c_str();
     int npts_i32 = (int) npts, ndims_i32 = (int) ndims;
     writer.write((char*) &npts_i32, sizeof(int));
     writer.write((char*) &ndims_i32, sizeof(int));
-    diskann::cout << "bin: #pts = " << npts << ", #dims = " << ndims
+    LOG(DEBUG) << "bin: #pts = " << npts << ", #dims = " << ndims
                   << ", size = " << npts * ndims * sizeof(T) + 2 * sizeof(int)
-                  << "B" << std::endl;
+                  << "B";
 
     //    data = new T[npts_u64 * ndims_u64];
     writer.write((char*) data, npts * ndims * sizeof(T));
     writer.close();
     size_t bytes_written = npts * ndims * sizeof(T) + 2 * sizeof(uint32_t);
-    diskann::cout << "Finished writing bin." << std::endl;
+    LOG(DEBUG) << "Finished writing bin.";
     return bytes_written;
   }
 
@@ -596,25 +590,24 @@ namespace diskann {
              << " while expected size is  " << expected_actual_file_size
              << " npts = " << npts << " dim = " << dim
              << " size of <T>= " << sizeof(T) << std::endl;
-      diskann::cout << stream.str() << std::endl;
+      LOG(ERROR) << stream.str();
       throw diskann::ANNException(stream.str(), -1, __FUNCSIG__, __FILE__,
                                   __LINE__);
     }
     rounded_dim = ROUND_UP(dim, 8);
-    diskann::cout << "Metadata: #pts = " << npts << ", #dims = " << dim
-                  << ", aligned_dim = " << rounded_dim << "... " << std::flush;
+    std::stringstream stream;
+    LOG(DEBUG) << "Metadata: #pts = " << npts << ", #dims = " << dim 
+           << ", aligned_dim = " << rounded_dim << "... ";
     size_t allocSize = npts * rounded_dim * sizeof(T);
-    diskann::cout << "allocating aligned memory of " << allocSize
-                  << " bytes... " << std::flush;
+    LOG(DEBUG) << "allocating aligned memory of " << allocSize << " bytes... ";
     alloc_aligned(((void**) &data), allocSize, 8 * sizeof(T));
-    diskann::cout << "done. Copying data to mem_aligned buffer..."
-                  << std::flush;
-
+    LOG(DEBUG) << "done. Copying data to mem_aligned buffer...";
+    
     for (size_t i = 0; i < npts; i++) {
       reader.read((char*) (data + i * rounded_dim), dim * sizeof(T));
       memset(data + i * rounded_dim + dim, 0, (rounded_dim - dim) * sizeof(T));
     }
-    diskann::cout << " done." << std::endl;
+    LOG(DEBUG) << " done." << std::endl;
   }
 
 #ifdef EXEC_ENV_OLS
@@ -644,8 +637,8 @@ namespace diskann {
     reader.exceptions(std::ifstream::failbit | std::ifstream::badbit);
 
     try {
-      diskann::cout << "Reading (with alignment) bin file " << bin_file
-                    << " ..." << std::flush;
+      LOG(DEBUG) << "Reading (with alignment) bin file " << bin_file
+                 << " ...";
       reader.open(bin_file, std::ios::binary | std::ios::ate);
 
       uint64_t fsize = reader.tellg();
@@ -678,8 +671,7 @@ namespace diskann {
   template<typename T>
   float prepare_base_for_inner_products(const std::string in_file,
                                         const std::string out_file) {
-    std::cout << "Pre-processing base file by adding extra coordinate"
-              << std::endl;
+    LOG(DEBUG) << "Pre-processing base file by adding extra coordinate";
     std::ifstream in_reader(in_file.c_str(), std::ios::binary);
     std::ofstream out_writer(out_file.c_str(), std::ios::binary);
     _u64          npts, in_dims, out_dims;

--- a/thirdparty/DiskANN/src/CMakeLists.txt
+++ b/thirdparty/DiskANN/src/CMakeLists.txt
@@ -10,6 +10,7 @@ else()
 	set(CPP_SOURCES ann_exception.cpp aux_utils.cpp distance.cpp index.cpp
         linux_aligned_file_reader.cpp math_utils.cpp memory_mapper.cpp
         partition_and_pq.cpp  pq_flash_index.cpp logger.cpp utils.cpp)
+	set(CPP_SOURCES ${CPP_SOURCES} ${KNOWHERE_SOURCE_DIR}/thirdparty/easyloggingpp/easylogging++.cc)
 	add_library(${PROJECT_NAME} STATIC ${CPP_SOURCES})
 	set_property(TARGET ${PROJECT_NAME} PROPERTY POSITION_INDEPENDENT_CODE ON)
 	# add_library(${PROJECT_NAME}_s STATIC ${CPP_SOURCES})

--- a/thirdparty/DiskANN/src/linux_aligned_file_reader.cpp
+++ b/thirdparty/DiskANN/src/linux_aligned_file_reader.cpp
@@ -140,8 +140,7 @@ void LinuxAlignedFileReader::register_thread() {
     std::cerr << "io_setup() failed; returned " << ret << ", errno=" << errno
               << ":" << ::strerror(errno) << std::endl;
   } else {
-    diskann::cout << "allocating ctx: " << ctx << " to thread-id:" << my_id
-                  << std::endl;
+    LOG(DEBUG) << "allocating ctx: " << ctx << " to thread-id:" << my_id;
     ctx_map[my_id] = ctx;
   }
   lk.unlock();
@@ -182,7 +181,7 @@ void LinuxAlignedFileReader::open(const std::string &fname) {
   this->file_desc = ::open(fname.c_str(), flags);
   // error checks
   assert(this->file_desc != -1);
-  std::cerr << "Opened file : " << fname << std::endl;
+  LOG(DEBUG) << "Opened file : " << fname;
 }
 
 void LinuxAlignedFileReader::close() {

--- a/thirdparty/DiskANN/src/math_utils.cpp
+++ b/thirdparty/DiskANN/src/math_utils.cpp
@@ -335,13 +335,13 @@ namespace kmeans {
       residual = lloyds_iter(data, num_points, dim, centers, num_centers,
                              docs_l2sq, closest_docs, closest_center);
 
-      diskann::cout << "Lloyd's iter " << i
-                    << "  dist_sq residual: " << residual << std::endl;
+      LOG(DEBUG) << "Lloyd's iter " << i
+                 << "  dist_sq residual: " << residual;
 
       if (((i != 0) && ((old_residual - residual) / residual) < 0.00001) ||
           (residual < std::numeric_limits<float>::epsilon())) {
-        diskann::cout << "Residuals unchanged: " << old_residual << " becomes "
-                      << residual << ". Early termination." << std::endl;
+        LOG(DEBUG) << "Residuals unchanged: " << old_residual << " becomes "
+                   << residual << ". Early termination.";
         break;
       }
     }
@@ -361,11 +361,11 @@ namespace kmeans {
     //	pivot_data = new float[num_centers * dim];
 
     std::vector<size_t> picked;
-    diskann::cout << "Selecting " << num_centers << " pivots from "
-                  << num_points << " points using ";
     std::random_device rd;
     auto               x = rd();
-    diskann::cout << "random seed " << x << std::endl;
+    LOG(DEBUG) << "Selecting " << num_centers << " pivots from "
+               << num_points << " points using " << "random seed "
+               << x;
     std::mt19937                          generator(x);
     std::uniform_int_distribution<size_t> distribution(0, num_points - 1);
 
@@ -392,12 +392,15 @@ namespace kmeans {
       return;
     }
 
+    std::stringstream stream;
     std::vector<size_t> picked;
-    diskann::cout << "Selecting " << num_centers << " pivots from "
-                  << num_points << " points using ";
     std::random_device rd;
     auto               x = rd();
-    diskann::cout << "random seed " << x << ": " << std::flush;
+
+    stream << "Selecting " << num_centers << " pivots from "
+           << num_points << " points using " << "random seed "
+           << x;
+
     std::mt19937                          generator(x);
     std::uniform_real_distribution<>      distribution(0, 1);
     std::uniform_int_distribution<size_t> int_dist(0, num_points - 1);
@@ -456,9 +459,10 @@ namespace kmeans {
       }
       num_picked++;
       if (num_picked % 32 == 0)
-        diskann::cout << "." << std::flush;
+        stream << "." << std::flush;
     }
-    diskann::cout << "done." << std::endl;
+    stream << "done.";
+    LOG(DEBUG) << stream.str();
     delete[] dist;
   }
 

--- a/thirdparty/DiskANN/src/utils.cpp
+++ b/thirdparty/DiskANN/src/utils.cpp
@@ -68,27 +68,23 @@ namespace diskann {
   diskann::Distance<float>* get_distance_function(diskann::Metric m) {
     if (m == diskann::Metric::L2) {
       if (Avx2SupportedCPU) {
-        diskann::cout << "L2: Using AVX2 distance computation DistanceL2Float" << std::endl;
+        LOG(INFO) << "L2: Using AVX2 distance computation DistanceL2Float";
         return new diskann::DistanceL2Float();
       } else if (AvxSupportedCPU) {
-        diskann::cout
-            << "L2: AVX2 not supported. Using AVX distance computation"
-            << std::endl;
+        LOG(WARNING) << "L2: AVX2 not supported. Using AVX distance computation";
         return new diskann::AVXDistanceL2Float();
       } else {
-        diskann::cout << "L2: Older CPU. Using slow distance computation"
-                      << std::endl;
+        LOG(WARNING) << "L2: Older CPU. Using slow distance computation";
         return new diskann::SlowDistanceL2Float();
       }
     } else if (m == diskann::Metric::COSINE) {   
-      diskann::cout << "Cosine: Using either AVX or AVX2 implementation"
-                    << std::endl;
+      LOG(INFO) << "Cosine: Using either AVX or AVX2 implementation";
       return new diskann::DistanceCosineFloat();
     } else if (m == diskann::Metric::INNER_PRODUCT) {
-      diskann::cout << "Inner product: Using AVX2 implementation AVXDistanceInnerProductFloat" << std::endl;
+      LOG(INFO) << "Inner product: Using AVX2 implementation AVXDistanceInnerProductFloat";
       return new diskann::AVXDistanceInnerProductFloat();
     } else if (m == diskann::Metric::FAST_L2) {
-      diskann::cout << "Fast_L2: Using AVX2 implementation with norm memoization DistanceFastL2<float>" << std::endl;
+      LOG(INFO) << "Fast_L2: Using AVX2 implementation with norm memoization DistanceFastL2<float>";
       return new diskann::DistanceFastL2<float>();
     } else {
       std::stringstream stream;
@@ -97,7 +93,7 @@ namespace diskann {
                 "{gopalsr, harshasi, rakri}@microsoft.com if you need support "
                 "for any other metric."
              << std::endl;
-      diskann::cerr << stream.str() << std::endl;
+      LOG(ERROR) << stream.str();
       throw diskann::ANNException(stream.str(), -1, __FUNCSIG__, __FILE__,
                                   __LINE__);
     }
@@ -107,20 +103,17 @@ namespace diskann {
   diskann::Distance<int8_t>* get_distance_function(diskann::Metric m) {
     if (m == diskann::Metric::L2) {
       if (Avx2SupportedCPU) {
-        diskann::cout << "Using AVX2 distance computation DistanceL2Int8." << std::endl;
+        LOG(INFO) << "Using AVX2 distance computation DistanceL2Int8.";
         return new diskann::DistanceL2Int8();
       } else if (AvxSupportedCPU) {
-        diskann::cout << "AVX2 not supported. Using AVX distance computation"
-                      << std::endl;
+        LOG(WARNING) << "AVX2 not supported. Using AVX distance computation";
         return new diskann::AVXDistanceL2Int8();
       } else {
-        diskann::cout << "Older CPU. Using slow distance computation SlowDistanceL2Int<int8_t>."
-                      << std::endl;
+        LOG(WARNING) << "Older CPU. Using slow distance computation SlowDistanceL2Int<int8_t>.";
         return new diskann::SlowDistanceL2Int<int8_t>();
       }
     } else if (m == diskann::Metric::COSINE) {
-      diskann::cout << "Using either AVX or AVX2 for Cosine similarity DistanceCosineInt8."
-                    << std::endl;
+      LOG(INFO) << "Using either AVX or AVX2 for Cosine similarity DistanceCosineInt8.";
       return new diskann::DistanceCosineInt8();
     } else {
       std::stringstream stream;
@@ -129,7 +122,7 @@ namespace diskann {
                 "{gopalsr, harshasi, rakri}@microsoft.com if you need support "
                 "for any other metric."
              << std::endl;
-      diskann::cerr << stream.str() << std::endl;
+      LOG(ERROR) << stream.str();
       throw diskann::ANNException(stream.str(), -1, __FUNCSIG__, __FILE__,
                                   __LINE__);
     }
@@ -139,7 +132,7 @@ namespace diskann {
   diskann::Distance<uint8_t>* get_distance_function(diskann::Metric m) {
     if (m == diskann::Metric::L2) {
 #ifdef _WINDOWS
-      diskann::cout
+      LOG(WARNING)
           << "WARNING: AVX/AVX2 distance function not defined for Uint8. Using "
              "slow version. "
              "Contact gopalsr@microsoft.com if you need AVX/AVX2 support."
@@ -147,11 +140,9 @@ namespace diskann {
 #endif
       return new diskann::DistanceL2UInt8();
     } else if (m == diskann::Metric::COSINE) {
-      diskann::cout
-          << "AVX/AVX2 distance function not defined for Uint8. Using "
-             "slow version SlowDistanceCosineUint8() "
-             "Contact gopalsr@microsoft.com if you need AVX/AVX2 support."
-          << std::endl;
+      LOG(WARNING) << "AVX/AVX2 distance function not defined for Uint8. Using "
+                      "slow version SlowDistanceCosineUint8() "
+                      "Contact gopalsr@microsoft.com if you need AVX/AVX2 support.";
       return new diskann::SlowDistanceCosineUInt8();
     } else {
       std::stringstream stream;
@@ -160,7 +151,7 @@ namespace diskann {
                 "{gopalsr, harshasi, rakri}@microsoft.com if you need support "
                 "for any other metric."
              << std::endl;
-      diskann::cerr << stream.str() << std::endl;
+      LOG(ERROR) << stream.str();
       throw diskann::ANNException(stream.str(), -1, __FUNCSIG__, __FILE__,
                                   __LINE__);
     }
@@ -198,14 +189,12 @@ namespace diskann {
     writr.write((char*) &ndims_s32, sizeof(_s32));
 
     _u64 npts = (_u64) npts_s32, ndims = (_u64) ndims_s32;
-    diskann::cout << "Normalizing FLOAT vectors in file: " << inFileName
-                  << std::endl;
-    diskann::cout << "Dataset: #pts = " << npts << ", # dims = " << ndims
-                  << std::endl;
+    LOG(DEBUG) << "Normalizing FLOAT vectors in file: " << inFileName
+               << "Dataset: #pts = " << npts << ", # dims = " << ndims;
 
     _u64 blk_size = 131072;
     _u64 nblks = ROUND_UP(npts, blk_size) / blk_size;
-    diskann::cout << "# blks: " << nblks << std::endl;
+    LOG(DEBUG) << "# blks: " << nblks;
 
     float* read_buf = new float[npts * ndims];
     for (_u64 i = 0; i < nblks; i++) {
@@ -214,8 +203,7 @@ namespace diskann {
     }
     delete[] read_buf;
 
-    diskann::cout << "Wrote normalized points to file: " << outFileName
-                  << std::endl;
+    LOG(DEBUG) << "Wrote normalized points to file: " << outFileName;
   }
 
 }  // namespace diskann

--- a/thirdparty/DiskANN/tests/range_search_disk_index.cpp
+++ b/thirdparty/DiskANN/tests/range_search_disk_index.cpp
@@ -109,8 +109,8 @@ int search_disk_index(diskann::Metric&   metric,
   }
   // cache bfs levels
   std::vector<uint32_t> node_list;
-  diskann::cout << "Caching " << num_nodes_to_cache
-                << " BFS nodes around medoid(s)" << std::endl;
+  LOG(INFO) << "Caching " << num_nodes_to_cache
+            << " BFS nodes around medoid(s)";
   _pFlashIndex->cache_bfs_levels(num_nodes_to_cache, node_list);
   //  _pFlashIndex->generate_cache_list_from_sample_queries(
   //      warmup_query_file, 15, 6, num_nodes_to_cache, num_threads, node_list);

--- a/thirdparty/DiskANN/tests/search_disk_index.cpp
+++ b/thirdparty/DiskANN/tests/search_disk_index.cpp
@@ -107,8 +107,8 @@ int search_disk_index(
   }
   // cache bfs levels
   std::vector<uint32_t> node_list;
-  diskann::cout << "Caching " << num_nodes_to_cache
-                << " BFS nodes around medoid(s)" << std::endl;
+  LOG(INFO) << "Caching " << num_nodes_to_cache
+            << " BFS nodes around medoid(s)";
   //_pFlashIndex->cache_bfs_levels(num_nodes_to_cache, node_list);
   if (num_nodes_to_cache > 0)
     _pFlashIndex->generate_cache_list_from_sample_queries(


### PR DESCRIPTION
Signed-off-by: matchyc <dawnlight.yc@protonmail.com>

related: #253 

1. Use `easylogging++` to replace `diskann::cout` in most situation. Set different log levels for outputs.
 - Use `build.sh -t Release` to hide annoying debug info.
2. Fix wrong output when building (alpha factor).
3. Remove redundant files when using `merged vamana` index.

Disable original diskann executable files for quicker building (let me know if we need them).