### PR TITLE
Fix diskann python api

### DIFF
--- a/python/knowhere/__init__.py
+++ b/python/knowhere/__init__.py
@@ -40,7 +40,7 @@ def CreateIndex(index_name, simd_type="auto"):
     )
 
 
-def CreateIndexDiskANN(index_name, index_prefix, metric_type, file_manager, simd_type="auto"):
+def CreateIndexDiskANN(index_name, index_prefix, metric_type, simd_type="auto"):
 
     if simd_type not in ["auto", "avx512", "avx2", "avx", "sse4_2"]:
         raise ValueError("simd type only support auto avx512 avx2 avx sse4_2")
@@ -48,11 +48,11 @@ def CreateIndexDiskANN(index_name, index_prefix, metric_type, file_manager, simd
     SetSimdType(simd_type)
 
     if index_name == "diskann_f":
-        return buildDiskANNf(index_prefix, metric_type, file_manager)
+        return buildDiskANNf(index_prefix, metric_type)
     if index_name == "diskann_i8":
-        return buildDiskANNi8(index_prefix, metric_type, file_manager)
+        return buildDiskANNi8(index_prefix, metric_type)
     if index_name == "diskann_ui8":
-        return buildDiskANNui8(index_prefix, metric_type, file_manager)
+        return buildDiskANNui8(index_prefix, metric_type)
     raise ValueError(
         """ index name only support 
             'diskann_f' 'diskann_i8' 'diskann_ui8'."""

--- a/unittest/pycase/test_diskann.py
+++ b/unittest/pycase/test_diskann.py
@@ -12,7 +12,7 @@ def test_diskann():
     except:
         pass 
     os.mkdir(tmp_path)
-    idx = knowhere.CreateIndexDiskANN("diskann_f", os.path.join(tmp_path, "index"), "L2", knowhere.EmptyFileManager())
+    idx = knowhere.CreateIndexDiskANN("diskann_f", os.path.join(tmp_path, "index"), "L2")
     shape = np.array([10000, 128]).astype(np.int32)
     arr = np.random.uniform(1, 5, [10000, 128]).astype(np.float32)
     data_path = os.path.join(tmp_path, "diskann_data")


### PR DESCRIPTION
Signed-off-by: zh Wang <zihao.wang@zilliz.com>

issue: #366 

Fix some problems of python API for DiskANN
1. Remove support for `FileManager` in python API cause it's not useful in testing.
2. Fix `CreateConfig` when creating config for DiskANN.