### PR TITLE
api for concurrency when build and query

### DIFF
--- a/knowhere/index/vector_index/helpers/IndexParameter.h
+++ b/knowhere/index/vector_index/helpers/IndexParameter.h
@@ -35,6 +35,8 @@ constexpr const char* RADIUS = "radius";
 constexpr const char* INPUT_IDS = "input_ids";
 constexpr const char* OUTPUT_TENSOR = "output_tensor";
 constexpr const char* DEVICE_ID = "gpu_id";
+constexpr const char* BUILD_THREAD_NUM = "build_thread_num";
+constexpr const char* QUERY_THREAD_NUM = "query_thread_num";
 };  // namespace meta
 
 namespace indexparam {
@@ -136,6 +138,12 @@ DEFINE_CONFIG_SETTER(SetMetaRadius, meta::RADIUS, float)
 
 DEFINE_CONFIG_GETTER(GetMetaDeviceID, meta::DEVICE_ID, int64_t)
 DEFINE_CONFIG_SETTER(SetMetaDeviceID, meta::DEVICE_ID, int64_t)
+
+DEFINE_CONFIG_GETTER(GetMetaBuildThreadNum, meta::BUILD_THREAD_NUM, int64_t)
+DEFINE_CONFIG_SETTER(SetMetaBuildThreadNum, meta::BUILD_THREAD_NUM, int64_t)
+
+DEFINE_CONFIG_GETTER(GetMetaQueryThreadNum, meta::QUERY_THREAD_NUM, int64_t)
+DEFINE_CONFIG_SETTER(SetMetaQueryThreadNum, meta::QUERY_THREAD_NUM, int64_t)
 
 ///////////////////////////////////////////////////////////////////////////////
 // APIs to access indexparam

--- a/unittest/Helper.h
+++ b/unittest/Helper.h
@@ -37,6 +37,8 @@ constexpr int64_t K = 10;
 constexpr int64_t PINMEM = 1024 * 1024 * 200;
 constexpr int64_t TEMPMEM = 1024 * 1024 * 300;
 constexpr int64_t RESNUM = 2;
+constexpr int64_t BUILD_THREAD_NUM = 3;
+constexpr int64_t QUERY_THREAD_NUM = 4;
 
 class ParamGenerator {
  public:
@@ -75,6 +77,8 @@ class ParamGenerator {
                 {knowhere::meta::DIM, DIM},
                 {knowhere::meta::TOPK, K},
                 {knowhere::meta::DEVICE_ID, DEVICE_ID},
+                {knowhere::meta::BUILD_THREAD_NUM, BUILD_THREAD_NUM},
+                {knowhere::meta::QUERY_THREAD_NUM, QUERY_THREAD_NUM},
                 {knowhere::indexparam::NLIST, 16},
                 {knowhere::indexparam::NPROBE, 8},
             };
@@ -117,6 +121,8 @@ class ParamGenerator {
                 {knowhere::meta::METRIC_TYPE, knowhere::metric::L2},
                 {knowhere::meta::DIM, DIM},
                 {knowhere::meta::TOPK, K},
+                {knowhere::meta::BUILD_THREAD_NUM, BUILD_THREAD_NUM},
+                {knowhere::meta::QUERY_THREAD_NUM, QUERY_THREAD_NUM},
                 {knowhere::indexparam::HNSW_M, 16},
                 {knowhere::indexparam::EFCONSTRUCTION, 200},
                 {knowhere::indexparam::EF, 200},


### PR DESCRIPTION
Signed-off-by: xinguo.li  <xinguo.li@zilliz.com>

issue: #374 

We added two parameters in the config, build_thread_num and query_thread_num. It can help to control the number of threads if you input parameters when build and query. Only hnsw and ivy_flat were accepted the changes for the reason that we need to solve problems in a short time.