### PR TITLE
Add unit test for bitset

### DIFF
--- a/knowhere/index/vector_index/IndexDiskANN.cpp
+++ b/knowhere/index/vector_index/IndexDiskANN.cpp
@@ -398,7 +398,8 @@ IndexDiskANN<T>::QueryByRange(const DatasetPtr& dataset_ptr, const Config& confi
         try {
             res_count = TryDiskANNCallAndThrow<uint32_t>([&]() -> uint32_t {
                 return pq_flash_index_->range_search(query + (row * dim), radius, query_conf.min_k, query_conf.max_k,
-                                                     indices, distances, query_conf.beamwidth, bitset);
+                                                     indices, distances, query_conf.beamwidth,
+                                                     query_conf.search_list_and_k_ratio, bitset);
             });
         } catch (const KnowhereException& e) {
 #pragma omp critical

--- a/knowhere/index/vector_index/IndexDiskANNConfig.cpp
+++ b/knowhere/index/vector_index/IndexDiskANNConfig.cpp
@@ -38,6 +38,7 @@ static constexpr const char* kBeamwidth = "beamwidth";
 static constexpr const char* kRadius = "radius";
 static constexpr const char* kMinK = "min_k";
 static constexpr const char* kMaxK = "max_k";
+static constexpr const char* kSearchListAndKRatio = "search_list_and_k_ratio";
 
 static constexpr const char* kDiskANNBuildConfig = "diskANN_build_config";
 static constexpr const char* kDiskANNPrepareConfig = "diskANN_prepare_config";
@@ -169,7 +170,8 @@ to_json(Config& config, const DiskANNQueryByRangeConfig& query_conf) {
     config = Config{{kRadius, query_conf.radius},
                     {kMinK, query_conf.min_k},
                     {kMaxK, query_conf.max_k},
-                    {kBeamwidth, query_conf.beamwidth}};
+                    {kBeamwidth, query_conf.beamwidth},
+                    {kSearchListAndKRatio, query_conf.search_list_and_k_ratio}};
 }
 
 void
@@ -178,6 +180,7 @@ from_json(const Config& config, DiskANNQueryByRangeConfig& query_conf) {
     CheckNumericParamAndSet<uint64_t>(config, kMinK, 1, std::nullopt, query_conf.min_k);
     CheckNumericParamAndSet<uint64_t>(config, kMaxK, query_conf.min_k, std::nullopt, query_conf.max_k);
     CheckNumericParamAndSet<uint32_t>(config, kBeamwidth, 1, 128, query_conf.beamwidth);
+    CheckNumericParamAndSet<float>(config, kSearchListAndKRatio, 1.0, 5.0, query_conf.search_list_and_k_ratio);
 }
 
 DiskANNBuildConfig

--- a/knowhere/index/vector_index/IndexDiskANNConfig.h
+++ b/knowhere/index/vector_index/IndexDiskANNConfig.h
@@ -106,6 +106,9 @@ struct DiskANNQueryByRangeConfig {
     uint64_t max_k;
     // Beamwidth used for TopK search.
     uint32_t beamwidth;
+    // DiskANN uses TopK search to simulate range search, this is the ratio of search list size and k. With larger
+    // ratio, the accuracy will get higher but throughput will get affected.
+    float search_list_and_k_ratio = 2;
 
     static DiskANNQueryByRangeConfig
     Get(const Config& config);

--- a/thirdparty/DiskANN/include/pq_flash_index.h
+++ b/thirdparty/DiskANN/include/pq_flash_index.h
@@ -105,6 +105,7 @@ namespace diskann {
                                         std::vector<_s64> & indices,
                                         std::vector<float> &distances,
                                         const _u64          beam_width,
+                                        const float         l_k_ratio,
                                         faiss::BitsetView   bitset_view = nullptr,
                                         QueryStats *        stats = nullptr);
 

--- a/thirdparty/DiskANN/src/pq_flash_index.cpp
+++ b/thirdparty/DiskANN/src/pq_flash_index.cpp
@@ -1250,6 +1250,7 @@ namespace diskann {
                                      std::vector<_s64> & indices,
                                      std::vector<float> &distances,
                                      const _u64          beam_width,
+                                     const float         l_k_ratio,
                                      faiss::BitsetView   bitset_view,
                                      QueryStats *        stats) {
     _u32 res_count = 0;
@@ -1262,11 +1263,11 @@ namespace diskann {
       distances.resize(l_search);
       for (auto &x : distances)
         x = std::numeric_limits<float>::max();
-      this->cached_beam_search(query1, l_search, l_search, indices.data(),
-                               distances.data(), beam_width, false, stats,
-                               bitset_view);
+      this->cached_beam_search(query1, l_search, l_k_ratio * l_search,
+                               indices.data(), distances.data(), beam_width,
+                               false, stats, bitset_view);
       for (_u32 i = 0; i < l_search; i++) {
-        if (distances[i] > (float) range) {
+        if (distances[i] > (float) range || indices[i] == -1) {
           res_count = i;
           break;
         } else if (i == l_search - 1)

--- a/thirdparty/DiskANN/tests/range_search_disk_index.cpp
+++ b/thirdparty/DiskANN/tests/range_search_disk_index.cpp
@@ -203,7 +203,7 @@ int search_disk_index(diskann::Metric&   metric,
       std::vector<float> distances;
       _u32               res_count = _pFlashIndex->range_search(
                         query + (i * query_aligned_dim), search_range, L, max_list_size,
-                        indices, distances, optimized_beamwidth, nullptr, stats + i);
+                        indices, distances, optimized_beamwidth, 1.0, nullptr, stats + i);
 
       query_result_ids[test_id][i].reserve(res_count);
       query_result_ids[test_id][i].resize(res_count);


### PR DESCRIPTION
Signed-off-by: liliu-z <li.liu@zilliz.com>

Issue: #253 

This PR did:
1. Add bitset unittest for DiskANN
2. Add a config for range search to allow user set the ratio of search list size and k. Before this change the default value is 1, much make recall too low.
3. Filter the -1 in range search result. (-1 is from KNN search, when the result is not enough, KNN search will fill the ids with -1).
4. Format the unittest for DiskANN