### PR TITLE
Fix thread problem for DiskANN

### DIFF
--- a/knowhere/index/vector_index/IndexDiskANN.cpp
+++ b/knowhere/index/vector_index/IndexDiskANN.cpp
@@ -283,6 +283,7 @@ IndexDiskANN<T>::Prepare(const Config& config) {
 
     // set thread number
     omp_set_num_threads(prep_conf.num_threads);
+    num_threads_ = prep_conf.num_threads;
 
     // warmup
     if (prep_conf.warm_up) {
@@ -337,6 +338,9 @@ DatasetPtr
 IndexDiskANN<T>::Query(const DatasetPtr& dataset_ptr, const Config& config, const faiss::BitsetView bitset) {
     CheckPreparation(is_prepared_);
 
+    // set thread number
+    omp_set_num_threads(num_threads_);
+
     auto query_conf = DiskANNQueryConfig::Get(config);
     auto& k = query_conf.k;
 
@@ -376,6 +380,9 @@ template <typename T>
 DatasetPtr
 IndexDiskANN<T>::QueryByRange(const DatasetPtr& dataset_ptr, const Config& config, const faiss::BitsetView bitset) {
     CheckPreparation(is_prepared_);
+
+    // set thread number
+    omp_set_num_threads(num_threads_);
 
     auto query_conf = DiskANNQueryByRangeConfig::Get(config);
     auto& radius = query_conf.radius;

--- a/knowhere/index/vector_index/IndexDiskANN.h
+++ b/knowhere/index/vector_index/IndexDiskANN.h
@@ -101,6 +101,7 @@ class IndexDiskANN : public VecIndex {
     std::unique_ptr<diskann::PQFlashIndex<T>> pq_flash_index_;
 
     bool is_prepared_ = false;
+    int32_t num_threads_  = 0;
     std::mutex preparation_lock_;
 };
 


### PR DESCRIPTION
Signed-off-by: liuli <li.liu@zilliz.com>

**Problem**: We need to set omp thread limit for each thread using omp block. Now we only set in `Prepare()`, because in original `DiskANN`, they do prepare and search in one thread. So we need to set this limit every time we do query.