### PR TITLE
Feat: add fast build index option

### DIFF
--- a/thirdparty/DiskANN/include/aux_utils.h
+++ b/thirdparty/DiskANN/include/aux_utils.h
@@ -99,7 +99,7 @@ namespace diskann {
   template<typename T>
   DISKANN_DLLEXPORT int build_merged_vamana_index(
       std::string base_file, diskann::Metric _compareMetric, unsigned L,
-      unsigned R, double sampling_rate, double ram_budget,
+      unsigned R, bool accelerate_build, double sampling_rate, double ram_budget,
       std::string mem_index_path, std::string medoids_file,
       std::string centroids_file);
 

--- a/thirdparty/DiskANN/src/aux_utils.cpp
+++ b/thirdparty/DiskANN/src/aux_utils.cpp
@@ -544,7 +544,7 @@ namespace diskann {
   template<typename T>
   int build_merged_vamana_index(std::string     base_file,
                                 diskann::Metric compareMetric, unsigned L,
-                                unsigned R, double sampling_rate,
+                                unsigned R, bool accelerate_build, double sampling_rate,
                                 double ram_budget, std::string mem_index_path,
                                 std::string medoids_file,
                                 std::string centroids_file) {
@@ -565,6 +565,7 @@ namespace diskann {
       paras.Set<unsigned>("num_rnds", 2);
       paras.Set<bool>("saturate_graph", 1);
       paras.Set<std::string>("save_path", mem_index_path);
+      paras.Set<bool>("accelerate_build", accelerate_build);
 
       std::unique_ptr<diskann::Index<T>> _pvamanaIndex =
           std::unique_ptr<diskann::Index<T>>(new diskann::Index<T>(
@@ -605,6 +606,7 @@ namespace diskann {
       paras.Set<unsigned>("num_rnds", 2);
       paras.Set<bool>("saturate_graph", 0);
       paras.Set<std::string>("save_path", shard_index_file);
+      paras.Set<bool>("accelerate_build", accelerate_build);
 
       _u64 shard_base_dim, shard_base_pts;
       get_bin_metadata(shard_base_file, shard_base_pts, shard_base_dim);
@@ -921,7 +923,7 @@ namespace diskann {
       param_list.push_back(cur_param);
     }
     if (param_list.size() != 5 && param_list.size() != 6 &&
-        param_list.size() != 7) {
+        param_list.size() != 7 && param_list.size() != 8) {
       LOG(ERROR)
           << "Correct usage of parameters is R (max degree) "
              "L (indexing list size, better if >= R)"
@@ -931,7 +933,9 @@ namespace diskann {
              "B' (PQ bytes for disk index: optional parameter for "
              "very large dimensional data)"
              "reorder (set true to include full precision in data file"
-             ": optional paramter, use only when using disk PQ";
+             ": optional paramter, use only when using disk PQ"
+             "accelerate_build (build index faster but lower search recall)"
+             ": optional paramter";
       return -1;
     }
 
@@ -961,6 +965,13 @@ namespace diskann {
     if (param_list.size() == 7) {
       if (1 == atoi(param_list[6].c_str())) {
         reorder_data = true;
+      }
+    }
+
+    bool accelerate_build = false;
+    if (param_list.size() == 8){
+      if(1 == atoi(param_list[7].c_str())){
+        accelerate_build = true;
       }
     }
 
@@ -1097,7 +1108,7 @@ namespace diskann {
 #endif
 
     diskann::build_merged_vamana_index<T>(
-        data_file_to_use.c_str(), diskann::Metric::L2, L, R, p_val,
+        data_file_to_use.c_str(), diskann::Metric::L2, L, R, accelerate_build, p_val,
         indexing_ram_budget, mem_index_path, medoids_path, centroids_path);
 
     if (!use_disk_pq) {
@@ -1195,17 +1206,17 @@ namespace diskann {
 
   template DISKANN_DLLEXPORT int build_merged_vamana_index<int8_t>(
       std::string base_file, diskann::Metric compareMetric, unsigned L,
-      unsigned R, double sampling_rate, double ram_budget,
+      unsigned R, bool accelerate_build, double sampling_rate, double ram_budget,
       std::string mem_index_path, std::string medoids_path,
       std::string centroids_file);
   template DISKANN_DLLEXPORT int build_merged_vamana_index<float>(
       std::string base_file, diskann::Metric compareMetric, unsigned L,
-      unsigned R, double sampling_rate, double ram_budget,
+      unsigned R, bool accelerate_build, double sampling_rate, double ram_budget,
       std::string mem_index_path, std::string medoids_path,
       std::string centroids_file);
   template DISKANN_DLLEXPORT int build_merged_vamana_index<uint8_t>(
       std::string base_file, diskann::Metric compareMetric, unsigned L,
-      unsigned R, double sampling_rate, double ram_budget,
+      unsigned R, bool accelerate_build, double sampling_rate, double ram_budget,
       std::string mem_index_path, std::string medoids_path,
       std::string centroids_file);
 };  // namespace diskann

--- a/thirdparty/DiskANN/src/index.cpp
+++ b/thirdparty/DiskANN/src/index.cpp
@@ -1408,6 +1408,7 @@ namespace diskann {
     _indexingQueueSize = parameters.Get<unsigned>("L");  // Search list size
     _indexingRange = parameters.Get<unsigned>("R");
     _indexingMaxC = parameters.Get<unsigned>("C");
+    const bool accelerate_build = parameters.Get<bool>("accelerate_build");
     const float last_round_alpha = parameters.Get<float>("alpha");
     unsigned    L = _indexingQueueSize;
 
@@ -1461,6 +1462,11 @@ namespace diskann {
     // random other nodes
     std::set<unsigned> unique_start_points;
     unique_start_points.insert(_ep);
+    if(accelerate_build){
+      while (unique_start_points.size() < 128){
+        unique_start_points.insert(_nd * dis(gen));
+      }
+    }
 
     std::vector<unsigned> init_ids;
     for (auto pt : unique_start_points)
@@ -1486,7 +1492,12 @@ namespace diskann {
 
       std::vector<std::vector<unsigned>> pruned_list_vector(round_size);
 
-      for (uint32_t sync_num = 0; sync_num < num_syncs; sync_num++) {
+      auto round_num_syncs = num_syncs;
+      if(accelerate_build && rnd_no == 0){
+        round_num_syncs = num_syncs * 0.05;
+      }
+
+      for (uint32_t sync_num = 0; sync_num < round_num_syncs; sync_num++) {
         size_t start_id = sync_num * round_size;
         size_t end_id =
             (std::min)(_nd + _num_frozen_pts, (sync_num + 1) * round_size);


### PR DESCRIPTION
Signed-off-by: wusonglin] <songlin.wu@zilliz.com>
Since diskann has a tow-rounds build index, it is clear that only one round can save a lot of time for index building. And the recall loss is very small which can be ignored in many scenarios.
more information: 
[DiskAnn/SSD_HNSW Tests on AWS m6id.2xlarge](https://zilliverse.feishu.cn/sheets/shtcn6NrMjb1TwVBszveHyECnFd?sheet=8e0b9d) shows this optimization has saved 35% build time and lost no more than 1% recall in two KNN search dataset.
[index build optimized records](https://zilliverse.feishu.cn/docx/doxcnYeKNTJwIcxxZzcEARI2Eqg) document the optimization ideas in detail. small sync size in round 1 and more entry points help the vanama graph grows better at the Initial.