### PR TITLE
Add api to control thread for all index

### DIFF
--- a/knowhere/index/vector_index/IndexAnnoy.cpp
+++ b/knowhere/index/vector_index/IndexAnnoy.cpp
@@ -11,6 +11,8 @@
 
 #include "IndexAnnoy.h"
 
+#include <omp.h>
+
 #include <algorithm>
 #include <cassert>
 #include <iterator>
@@ -141,7 +143,11 @@ IndexAnnoy::Query(const DatasetPtr& dataset_ptr, const Config& config, const fai
     auto search_k = GetIndexParamSearchK(config);
     auto p_id = new int64_t[k * rows];
     auto p_dist = new float[k * rows];
-
+    if (CheckKeyInConfig(config, meta::QUERY_THREAD_NUM)) {
+        omp_set_num_threads(GetMetaQueryThreadNum(config));
+    } else {
+        omp_set_num_threads(knowhere::DEFAULT_QUERY_THREAD_NUM);
+    }
 #pragma omp parallel for
     for (unsigned int i = 0; i < rows; ++i) {
         std::vector<int64_t> result;

--- a/knowhere/index/vector_index/IndexBinaryIDMAP.cpp
+++ b/knowhere/index/vector_index/IndexBinaryIDMAP.cpp
@@ -9,9 +9,10 @@
 // is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 // or implied. See the License for the specific language governing permissions and limitations under the License.
 
-#include <string>
 #include <faiss/IndexBinaryFlat.h>
 #include <faiss/MetaIndexes.h>
+#include <omp.h>
+#include <string>
 
 #include "common/Exception.h"
 #include "index/vector_index/IndexBinaryIDMAP.h"
@@ -92,6 +93,11 @@ BinaryIDMAP::Query(const DatasetPtr& dataset_ptr, const Config& config, const fa
         p_id = new int64_t[k * rows];
         p_dist = new float[k * rows];
 
+        if (CheckKeyInConfig(config, meta::QUERY_THREAD_NUM)) {
+            omp_set_num_threads(GetMetaQueryThreadNum(config));
+        } else {
+            omp_set_num_threads(knowhere::DEFAULT_QUERY_THREAD_NUM);
+        }
         QueryImpl(rows, reinterpret_cast<const uint8_t*>(p_data), k, p_dist, p_id, config, bitset);
 
         return GenResultDataset(p_id, p_dist);
@@ -132,6 +138,11 @@ BinaryIDMAP::QueryByRange(const DatasetPtr& dataset,
     };
 
     try {
+        if (CheckKeyInConfig(config, meta::QUERY_THREAD_NUM)) {
+            omp_set_num_threads(GetMetaQueryThreadNum(config));
+        } else {
+            omp_set_num_threads(knowhere::DEFAULT_QUERY_THREAD_NUM);
+        }
         QueryByRangeImpl(rows, reinterpret_cast<const uint8_t*>(p_data), radius, p_dist, p_id, p_lims, config, bitset);
         return GenResultDataset(p_id, p_dist, p_lims);
     } catch (faiss::FaissException& e) {

--- a/knowhere/index/vector_index/IndexHNSW.cpp
+++ b/knowhere/index/vector_index/IndexHNSW.cpp
@@ -9,18 +9,20 @@
 // is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 // or implied. See the License for the specific language governing permissions and limitations under the License.
 
+#include "index/vector_index/IndexHNSW.h"
+
+#include <omp.h>
+
 #include <algorithm>
 #include <chrono>
 #include <queue>
 #include <string>
 #include <utility>
 #include <vector>
-#include <omp.h>
 
 #include "common/Exception.h"
 #include "common/Log.h"
 #include "hnswlib/hnswlib/hnswalg.h"
-#include "index/vector_index/IndexHNSW.h"
 #include "index/vector_index/adapter/VectorAdapter.h"
 #include "index/vector_index/helpers/FaissIO.h"
 
@@ -105,8 +107,12 @@ IndexHNSW::AddWithoutIds(const DatasetPtr& dataset_ptr, const Config& config) {
     GET_TENSOR_DATA(dataset_ptr)
 
     index_->addPoint(p_data, 0);
-if (CheckKeyInConfig(config, meta::BUILD_THREAD_NUM))
-    omp_set_num_threads(GetMetaBuildThreadNum(config));
+
+    if (CheckKeyInConfig(config, meta::BUILD_THREAD_NUM)) {
+        omp_set_num_threads(GetMetaBuildThreadNum(config));
+    } else {
+        omp_set_num_threads(knowhere::DEFAULT_BUILD_THREAD_NUM);
+    }
 #pragma omp parallel for
     for (int i = 1; i < rows; ++i) {
         index_->addPoint((reinterpret_cast<const float*>(p_data) + Dim() * i), i);
@@ -172,8 +178,12 @@ IndexHNSW::Query(const DatasetPtr& dataset_ptr, const Config& config, const fais
     std::chrono::high_resolution_clock::time_point query_start, query_end;
     query_start = std::chrono::high_resolution_clock::now();
 
-if (CheckKeyInConfig(config, meta::QUERY_THREAD_NUM))
-    omp_set_num_threads(GetMetaQueryThreadNum(config));
+    if (CheckKeyInConfig(config, meta::QUERY_THREAD_NUM)) {
+        omp_set_num_threads(GetMetaQueryThreadNum(config));
+    } else {
+        omp_set_num_threads(knowhere::DEFAULT_QUERY_THREAD_NUM);
+    }
+
 #pragma omp parallel for
     for (unsigned int i = 0; i < rows; ++i) {
         auto single_query = (float*)p_data + i * dim;

--- a/knowhere/index/vector_index/IndexIDMAP.cpp
+++ b/knowhere/index/vector_index/IndexIDMAP.cpp
@@ -14,6 +14,7 @@
 #include <faiss/MetaIndexes.h>
 #include <faiss/clone_index.h>
 #include <faiss/index_io.h>
+#include <omp.h>
 #ifdef KNOWHERE_GPU_VERSION
 #include <faiss/gpu/GpuCloner.h>
 #endif
@@ -125,6 +126,11 @@ IDMAP::Query(const DatasetPtr& dataset_ptr, const Config& config, const faiss::B
         p_id = new int64_t[k * rows];
         p_dist = new float[k * rows];
 
+        if (CheckKeyInConfig(config, meta::QUERY_THREAD_NUM)) {
+            omp_set_num_threads(GetMetaQueryThreadNum(config));
+        } else {
+            omp_set_num_threads(knowhere::DEFAULT_QUERY_THREAD_NUM);
+        }
         QueryImpl(rows, reinterpret_cast<const float*>(p_data), k, p_dist, p_id, config, bitset);
 
         return GenResultDataset(p_id, p_dist);

--- a/knowhere/index/vector_index/helpers/IndexParameter.h
+++ b/knowhere/index/vector_index/helpers/IndexParameter.h
@@ -39,6 +39,9 @@ constexpr const char* BUILD_THREAD_NUM = "build_thread_num";
 constexpr const char* QUERY_THREAD_NUM = "query_thread_num";
 };  // namespace meta
 
+const int64_t DEFAULT_BUILD_THREAD_NUM = 5;
+const int64_t DEFAULT_QUERY_THREAD_NUM = 6;
+
 namespace indexparam {
 // IVF Params
 constexpr const char* NPROBE = "nprobe";

--- a/unittest/Helper.h
+++ b/unittest/Helper.h
@@ -55,12 +55,15 @@ class ParamGenerator {
                 {knowhere::meta::METRIC_TYPE, knowhere::metric::HAMMING},
                 {knowhere::meta::DIM, DIM},
                 {knowhere::meta::TOPK, K},
+                {knowhere::meta::QUERY_THREAD_NUM, QUERY_THREAD_NUM},
             };
         } else if (type == knowhere::IndexEnum::INDEX_FAISS_BIN_IVFFLAT) {
             return knowhere::Config{
                 {knowhere::meta::METRIC_TYPE, knowhere::metric::HAMMING},
                 {knowhere::meta::DIM, DIM},
                 {knowhere::meta::TOPK, K},
+                {knowhere::meta::BUILD_THREAD_NUM, BUILD_THREAD_NUM},
+                {knowhere::meta::QUERY_THREAD_NUM, QUERY_THREAD_NUM},
                 {knowhere::indexparam::NLIST, 16},
                 {knowhere::indexparam::NPROBE, 8},
         };
@@ -70,6 +73,7 @@ class ParamGenerator {
                 {knowhere::meta::DIM, DIM},
                 {knowhere::meta::TOPK, K},
                 {knowhere::meta::DEVICE_ID, DEVICE_ID},
+                {knowhere::meta::QUERY_THREAD_NUM, QUERY_THREAD_NUM},
             };
         } else if (type == knowhere::IndexEnum::INDEX_FAISS_IVFFLAT) {
             return knowhere::Config{
@@ -88,6 +92,8 @@ class ParamGenerator {
                 {knowhere::meta::DIM, DIM},
                 {knowhere::meta::TOPK, K},
                 {knowhere::meta::DEVICE_ID, DEVICE_ID},
+                {knowhere::meta::BUILD_THREAD_NUM, BUILD_THREAD_NUM},
+                {knowhere::meta::QUERY_THREAD_NUM, QUERY_THREAD_NUM},
                 {knowhere::indexparam::NLIST, 16},
                 {knowhere::indexparam::NPROBE, 8},
                 {knowhere::indexparam::M, 4},
@@ -100,6 +106,8 @@ class ParamGenerator {
                 {knowhere::meta::DIM, DIM},
                 {knowhere::meta::TOPK, K},
                 {knowhere::meta::DEVICE_ID, DEVICE_ID},
+                {knowhere::meta::BUILD_THREAD_NUM, BUILD_THREAD_NUM},
+                {knowhere::meta::QUERY_THREAD_NUM, QUERY_THREAD_NUM},
                 {knowhere::indexparam::NLIST, 16},
                 {knowhere::indexparam::NPROBE, 8},
                 {knowhere::indexparam::NBITS, 8},
@@ -132,6 +140,7 @@ class ParamGenerator {
                 {knowhere::meta::METRIC_TYPE, knowhere::metric::L2},
                 {knowhere::meta::DIM, DIM},
                 {knowhere::meta::TOPK, K},
+                {knowhere::meta::QUERY_THREAD_NUM, QUERY_THREAD_NUM},
                 {knowhere::indexparam::N_TREES, 4},
                 {knowhere::indexparam::SEARCH_K, 100},
             };

--- a/unittest/test_idmap.cpp
+++ b/unittest/test_idmap.cpp
@@ -44,6 +44,7 @@ class IDMAPTest : public DataGen, public TestWithParam<knowhere::IndexMode> {
             {knowhere::meta::METRIC_TYPE, knowhere::metric::L2},
             {knowhere::meta::DIM, dim},
             {knowhere::meta::TOPK, k},
+            {knowhere::meta::QUERY_THREAD_NUM, QUERY_THREAD_NUM},
         };
         index_mode_ = GetParam();
         index_type_ = knowhere::IndexEnum::INDEX_FAISS_IDMAP;


### PR DESCRIPTION
Signed-off-by: lixinguo <xinguo.li@zilliz.com>
issue: #374 

It offers api to control threads when query and build in all indexes. You can add build_thread_num and query_thread_num when creating config and it offers the default values if you don't add it.