### PR TITLE
Add api to control omp threads for all index

### DIFF
--- a/knowhere/CMakeLists.txt
+++ b/knowhere/CMakeLists.txt
@@ -21,6 +21,7 @@ set(external_srcs
         common/Exception.cpp
         common/Timer.cpp
         common/Log.cpp
+        common/Utils.cpp
         ${KNOWHERE_THIRDPARTY_SRC}/easyloggingpp/easylogging++.cc
         )
 

--- a/knowhere/common/Utils.cpp
+++ b/knowhere/common/Utils.cpp
@@ -1,0 +1,34 @@
+// Copyright (C) 2019-2020 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under the License
+
+#include "common/Utils.h"
+
+#include "common/Log.h"
+
+namespace knowhere::utils {
+
+void
+SetBuildOmpThread(const Config& conf) {
+    int32_t omp_num =
+        CheckKeyInConfig(conf, meta::BUILD_INDEX_OMP_NUM) ? GetMetaBuildIndexOmpNum(conf) : omp_get_max_threads();
+    omp_set_num_threads(omp_num);
+    LOG_KNOWHERE_DEBUG_ << "Set current omp thread num for build: " << omp_num;
+}
+
+void
+SetQueryOmpThread(const Config& conf) {
+    int32_t omp_num =
+        CheckKeyInConfig(conf, meta::QUERY_OMP_NUM) ? GetMetaQueryOmpNum(conf) : omp_get_max_threads();
+    omp_set_num_threads(omp_num);
+    LOG_KNOWHERE_DEBUG_ << "Set current omp thread num for query: " << omp_num;
+}
+
+}  // namespace knowhere::utils

--- a/knowhere/common/Utils.h
+++ b/knowhere/common/Utils.h
@@ -1,0 +1,26 @@
+// Copyright (C) 2019-2020 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under the License
+
+#pragma once
+
+#include <omp.h>
+
+#include "knowhere/index/vector_index/helpers/IndexParameter.h"
+
+namespace knowhere::utils {
+
+void
+SetBuildOmpThread(const Config& conf);
+
+void
+SetQueryOmpThread(const Config& conf);
+
+}  // namespace knowhere::utils

--- a/knowhere/index/vector_index/IndexBinaryIDMAP.cpp
+++ b/knowhere/index/vector_index/IndexBinaryIDMAP.cpp
@@ -14,6 +14,7 @@
 #include <faiss/MetaIndexes.h>
 
 #include "common/Exception.h"
+#include "common/Utils.h"
 #include "index/vector_index/IndexBinaryIDMAP.h"
 #include "index/vector_index/adapter/VectorAdapter.h"
 
@@ -76,6 +77,7 @@ BinaryIDMAP::Query(const DatasetPtr& dataset_ptr, const Config& config, const fa
     }
     GET_TENSOR_DATA(dataset_ptr)
 
+    utils::SetQueryOmpThread(config);
     int64_t* p_id = nullptr;
     float* p_dist = nullptr;
     auto release_when_exception = [&]() {
@@ -113,6 +115,7 @@ BinaryIDMAP::QueryByRange(const DatasetPtr& dataset,
     }
     GET_TENSOR_DATA(dataset)
 
+    utils::SetQueryOmpThread(config);
     auto radius = GetMetaRadius(config);
 
     int64_t* p_id = nullptr;
@@ -166,7 +169,6 @@ BinaryIDMAP::AddWithoutIds(const DatasetPtr& dataset_ptr, const Config& config) 
     }
 
     GET_TENSOR_DATA(dataset_ptr)
-
     index_->add(rows, reinterpret_cast<const uint8_t*>(p_data));
 }
 
@@ -174,6 +176,7 @@ void
 BinaryIDMAP::Train(const DatasetPtr& dataset_ptr, const Config& config) {
     GET_TENSOR_DATA_DIM(dataset_ptr)
 
+    utils::SetBuildOmpThread(config);
     faiss::MetricType metric_type = GetFaissMetricType(config);
     auto index = std::make_shared<faiss::IndexBinaryFlat>(dim, metric_type);
     index_ = index;

--- a/knowhere/index/vector_index/IndexBinaryIVF.cpp
+++ b/knowhere/index/vector_index/IndexBinaryIVF.cpp
@@ -17,6 +17,7 @@
 
 #include "common/Exception.h"
 #include "common/Log.h"
+#include "common/Utils.h"
 #include "index/vector_index/IndexBinaryIVF.h"
 #include "index/vector_index/adapter/VectorAdapter.h"
 
@@ -89,6 +90,7 @@ BinaryIVF::Query(const DatasetPtr& dataset_ptr, const Config& config, const fais
 
     GET_TENSOR_DATA(dataset_ptr)
 
+    utils::SetQueryOmpThread(config);
     int64_t* p_id = nullptr;
     float* p_dist = nullptr;
     auto release_when_exception = [&]() {
@@ -126,6 +128,7 @@ BinaryIVF::QueryByRange(const DatasetPtr& dataset,
     }
     GET_TENSOR_DATA(dataset)
 
+    utils::SetQueryOmpThread(config);
     auto radius = GetMetaRadius(config);
 
     int64_t* p_id = nullptr;
@@ -217,6 +220,7 @@ void
 BinaryIVF::Train(const DatasetPtr& dataset_ptr, const Config& config) {
     GET_TENSOR_DATA_DIM(dataset_ptr)
 
+    utils::SetBuildOmpThread(config);
     int64_t nlist = GetIndexParamNlist(config);
     faiss::MetricType metric_type = GetFaissMetricType(config);
     faiss::IndexBinary* coarse_quantizer = new faiss::IndexBinaryFlat(dim, metric_type);

--- a/knowhere/index/vector_index/IndexIDMAP.cpp
+++ b/knowhere/index/vector_index/IndexIDMAP.cpp
@@ -22,6 +22,7 @@
 #include <vector>
 
 #include "common/Exception.h"
+#include "common/Utils.h"
 #include "index/vector_index/IndexIDMAP.h"
 #include "index/vector_index/adapter/VectorAdapter.h"
 #include "index/vector_index/helpers/FaissIO.h"
@@ -53,7 +54,7 @@ IDMAP::Load(const BinarySet& binary_set) {
 void
 IDMAP::Train(const DatasetPtr& dataset_ptr, const Config& config) {
     GET_TENSOR_DATA_DIM(dataset_ptr)
-
+    utils::SetBuildOmpThread(config);
     faiss::MetricType metric_type = GetFaissMetricType(config);
     auto index = std::make_shared<faiss::IndexFlat>(dim, metric_type);
     index_ = index;
@@ -109,6 +110,7 @@ IDMAP::Query(const DatasetPtr& dataset_ptr, const Config& config, const faiss::B
     }
     GET_TENSOR_DATA(dataset_ptr)
 
+    utils::SetQueryOmpThread(config);
     int64_t* p_id = nullptr;
     float* p_dist = nullptr;
     auto release_when_exception = [&]() {
@@ -146,6 +148,7 @@ IDMAP::QueryByRange(const DatasetPtr& dataset,
     }
     GET_TENSOR_DATA(dataset)
 
+    utils::SetQueryOmpThread(config);
     auto radius = GetMetaRadius(config);
 
     int64_t* p_id = nullptr;

--- a/knowhere/index/vector_index/IndexIVF.cpp
+++ b/knowhere/index/vector_index/IndexIVF.cpp
@@ -31,6 +31,7 @@
 
 #include "common/Exception.h"
 #include "common/Log.h"
+#include "common/Utils.h"
 #include "index/vector_index/IndexIVF.h"
 #include "index/vector_index/adapter/VectorAdapter.h"
 #include "index/vector_index/helpers/IndexParameter.h"
@@ -71,6 +72,7 @@ void
 IVF::Train(const DatasetPtr& dataset_ptr, const Config& config) {
     GET_TENSOR_DATA_DIM(dataset_ptr)
 
+    utils::SetBuildOmpThread(config);
     auto nlist = GetIndexParamNlist(config);
     faiss::MetricType metric_type = GetFaissMetricType(config);
     faiss::Index* coarse_quantizer = new faiss::IndexFlat(dim, metric_type);
@@ -132,6 +134,7 @@ IVF::Query(const DatasetPtr& dataset_ptr, const Config& config, const faiss::Bit
 
     GET_TENSOR_DATA(dataset_ptr)
 
+    utils::SetQueryOmpThread(config);
     int64_t* p_id = nullptr;
     float* p_dist = nullptr;
     auto release_when_exception = [&]() {
@@ -169,6 +172,7 @@ IVF::QueryByRange(const DatasetPtr& dataset,
     }
     GET_TENSOR_DATA(dataset)
 
+    utils::SetQueryOmpThread(config);
     auto radius = GetMetaRadius(config);
 
     int64_t* p_id = nullptr;

--- a/knowhere/index/vector_index/IndexIVFPQ.cpp
+++ b/knowhere/index/vector_index/IndexIVFPQ.cpp
@@ -20,6 +20,7 @@
 
 #include "common/Exception.h"
 #include "common/Log.h"
+#include "common/Utils.h"
 #include "index/vector_index/IndexIVFPQ.h"
 #include "index/vector_index/adapter/VectorAdapter.h"
 #include "index/vector_index/helpers/IndexParameter.h"
@@ -35,6 +36,7 @@ void
 IVFPQ::Train(const DatasetPtr& dataset_ptr, const Config& config) {
     GET_TENSOR_DATA_DIM(dataset_ptr)
 
+    utils::SetBuildOmpThread(config);
     faiss::MetricType metric_type = GetFaissMetricType(config);
     faiss::Index* coarse_quantizer = new faiss::IndexFlat(dim, metric_type);
     auto index = std::make_shared<faiss::IndexIVFPQ>(coarse_quantizer, dim, GetIndexParamNlist(config),

--- a/knowhere/index/vector_index/IndexIVFSQ.cpp
+++ b/knowhere/index/vector_index/IndexIVFSQ.cpp
@@ -21,6 +21,7 @@
 #include <faiss/clone_index.h>
 
 #include "common/Exception.h"
+#include "common/Utils.h"
 #include "index/vector_index/IndexIVFSQ.h"
 #include "index/vector_index/adapter/VectorAdapter.h"
 #include "index/vector_index/helpers/IndexParameter.h"
@@ -35,6 +36,7 @@ void
 IVFSQ::Train(const DatasetPtr& dataset_ptr, const Config& config) {
     GET_TENSOR_DATA_DIM(dataset_ptr)
 
+    knowhere::utils::SetBuildOmpThread(config);
     faiss::MetricType metric_type = GetFaissMetricType(config);
     faiss::Index* coarse_quantizer = new faiss::IndexFlat(dim, metric_type);
     auto index = std::make_shared<faiss::IndexIVFScalarQuantizer>(

--- a/knowhere/index/vector_index/helpers/IndexParameter.h
+++ b/knowhere/index/vector_index/helpers/IndexParameter.h
@@ -35,8 +35,8 @@ constexpr const char* RADIUS = "radius";
 constexpr const char* INPUT_IDS = "input_ids";
 constexpr const char* OUTPUT_TENSOR = "output_tensor";
 constexpr const char* DEVICE_ID = "gpu_id";
-constexpr const char* BUILD_THREAD_NUM = "build_thread_num";
-constexpr const char* QUERY_THREAD_NUM = "query_thread_num";
+constexpr const char* BUILD_INDEX_OMP_NUM = "build_index_omp_num";
+constexpr const char* QUERY_OMP_NUM = "query_omp_num";
 };  // namespace meta
 
 namespace indexparam {
@@ -139,11 +139,11 @@ DEFINE_CONFIG_SETTER(SetMetaRadius, meta::RADIUS, float)
 DEFINE_CONFIG_GETTER(GetMetaDeviceID, meta::DEVICE_ID, int64_t)
 DEFINE_CONFIG_SETTER(SetMetaDeviceID, meta::DEVICE_ID, int64_t)
 
-DEFINE_CONFIG_GETTER(GetMetaBuildThreadNum, meta::BUILD_THREAD_NUM, int64_t)
-DEFINE_CONFIG_SETTER(SetMetaBuildThreadNum, meta::BUILD_THREAD_NUM, int64_t)
+DEFINE_CONFIG_GETTER(GetMetaBuildIndexOmpNum, meta::BUILD_INDEX_OMP_NUM, int64_t)
+DEFINE_CONFIG_SETTER(SetMetaBuildIndexOmpNum, meta::BUILD_INDEX_OMP_NUM, int64_t)
 
-DEFINE_CONFIG_GETTER(GetMetaQueryThreadNum, meta::QUERY_THREAD_NUM, int64_t)
-DEFINE_CONFIG_SETTER(SetMetaQueryThreadNum, meta::QUERY_THREAD_NUM, int64_t)
+DEFINE_CONFIG_GETTER(GetMetaQueryOmpNum, meta::QUERY_OMP_NUM, int64_t)
+DEFINE_CONFIG_SETTER(SetMetaQueryOmpNum, meta::QUERY_OMP_NUM, int64_t)
 
 ///////////////////////////////////////////////////////////////////////////////
 // APIs to access indexparam

--- a/unittest/Helper.h
+++ b/unittest/Helper.h
@@ -37,8 +37,8 @@ constexpr int64_t K = 10;
 constexpr int64_t PINMEM = 1024 * 1024 * 200;
 constexpr int64_t TEMPMEM = 1024 * 1024 * 300;
 constexpr int64_t RESNUM = 2;
-constexpr int64_t BUILD_THREAD_NUM = 3;
-constexpr int64_t QUERY_THREAD_NUM = 4;
+constexpr int64_t BUILD_INDEX_OMP_NUM = 3;
+constexpr int64_t QUERY_OMP_NUM = 4;
 
 class ParamGenerator {
  public:
@@ -55,12 +55,16 @@ class ParamGenerator {
                 {knowhere::meta::METRIC_TYPE, knowhere::metric::HAMMING},
                 {knowhere::meta::DIM, DIM},
                 {knowhere::meta::TOPK, K},
+                {knowhere::meta::BUILD_INDEX_OMP_NUM, BUILD_INDEX_OMP_NUM},
+                {knowhere::meta::QUERY_OMP_NUM, QUERY_OMP_NUM},
             };
         } else if (type == knowhere::IndexEnum::INDEX_FAISS_BIN_IVFFLAT) {
             return knowhere::Config{
                 {knowhere::meta::METRIC_TYPE, knowhere::metric::HAMMING},
                 {knowhere::meta::DIM, DIM},
                 {knowhere::meta::TOPK, K},
+                {knowhere::meta::BUILD_INDEX_OMP_NUM, BUILD_INDEX_OMP_NUM},
+                {knowhere::meta::QUERY_OMP_NUM, QUERY_OMP_NUM},
                 {knowhere::indexparam::NLIST, 16},
                 {knowhere::indexparam::NPROBE, 8},
         };
@@ -70,6 +74,8 @@ class ParamGenerator {
                 {knowhere::meta::DIM, DIM},
                 {knowhere::meta::TOPK, K},
                 {knowhere::meta::DEVICE_ID, DEVICE_ID},
+                {knowhere::meta::BUILD_INDEX_OMP_NUM, BUILD_INDEX_OMP_NUM},
+                {knowhere::meta::QUERY_OMP_NUM, QUERY_OMP_NUM},
             };
         } else if (type == knowhere::IndexEnum::INDEX_FAISS_IVFFLAT) {
             return knowhere::Config{
@@ -77,8 +83,8 @@ class ParamGenerator {
                 {knowhere::meta::DIM, DIM},
                 {knowhere::meta::TOPK, K},
                 {knowhere::meta::DEVICE_ID, DEVICE_ID},
-                {knowhere::meta::BUILD_THREAD_NUM, BUILD_THREAD_NUM},
-                {knowhere::meta::QUERY_THREAD_NUM, QUERY_THREAD_NUM},
+                {knowhere::meta::BUILD_INDEX_OMP_NUM, BUILD_INDEX_OMP_NUM},
+                {knowhere::meta::QUERY_OMP_NUM, QUERY_OMP_NUM},
                 {knowhere::indexparam::NLIST, 16},
                 {knowhere::indexparam::NPROBE, 8},
             };
@@ -88,6 +94,8 @@ class ParamGenerator {
                 {knowhere::meta::DIM, DIM},
                 {knowhere::meta::TOPK, K},
                 {knowhere::meta::DEVICE_ID, DEVICE_ID},
+                {knowhere::meta::BUILD_INDEX_OMP_NUM, BUILD_INDEX_OMP_NUM},
+                {knowhere::meta::QUERY_OMP_NUM, QUERY_OMP_NUM},
                 {knowhere::indexparam::NLIST, 16},
                 {knowhere::indexparam::NPROBE, 8},
                 {knowhere::indexparam::M, 4},
@@ -100,6 +108,8 @@ class ParamGenerator {
                 {knowhere::meta::DIM, DIM},
                 {knowhere::meta::TOPK, K},
                 {knowhere::meta::DEVICE_ID, DEVICE_ID},
+                {knowhere::meta::BUILD_INDEX_OMP_NUM, BUILD_INDEX_OMP_NUM},
+                {knowhere::meta::QUERY_OMP_NUM, QUERY_OMP_NUM},
                 {knowhere::indexparam::NLIST, 16},
                 {knowhere::indexparam::NPROBE, 8},
                 {knowhere::indexparam::NBITS, 8},
@@ -121,8 +131,8 @@ class ParamGenerator {
                 {knowhere::meta::METRIC_TYPE, knowhere::metric::L2},
                 {knowhere::meta::DIM, DIM},
                 {knowhere::meta::TOPK, K},
-                {knowhere::meta::BUILD_THREAD_NUM, BUILD_THREAD_NUM},
-                {knowhere::meta::QUERY_THREAD_NUM, QUERY_THREAD_NUM},
+                {knowhere::meta::BUILD_INDEX_OMP_NUM, BUILD_INDEX_OMP_NUM},
+                {knowhere::meta::QUERY_OMP_NUM, QUERY_OMP_NUM},
                 {knowhere::indexparam::HNSW_M, 16},
                 {knowhere::indexparam::EFCONSTRUCTION, 200},
                 {knowhere::indexparam::EF, 200},
@@ -132,6 +142,8 @@ class ParamGenerator {
                 {knowhere::meta::METRIC_TYPE, knowhere::metric::L2},
                 {knowhere::meta::DIM, DIM},
                 {knowhere::meta::TOPK, K},
+                {knowhere::meta::BUILD_INDEX_OMP_NUM, BUILD_INDEX_OMP_NUM},
+                {knowhere::meta::QUERY_OMP_NUM, QUERY_OMP_NUM},
                 {knowhere::indexparam::N_TREES, 4},
                 {knowhere::indexparam::SEARCH_K, 100},
             };

--- a/unittest/test_idmap.cpp
+++ b/unittest/test_idmap.cpp
@@ -44,6 +44,7 @@ class IDMAPTest : public DataGen, public TestWithParam<knowhere::IndexMode> {
             {knowhere::meta::METRIC_TYPE, knowhere::metric::L2},
             {knowhere::meta::DIM, dim},
             {knowhere::meta::TOPK, k},
+            {knowhere::meta::QUERY_OMP_NUM, QUERY_OMP_NUM},
         };
         index_mode_ = GetParam();
         index_type_ = knowhere::IndexEnum::INDEX_FAISS_IDMAP;


### PR DESCRIPTION
Signed-off-by: lixinguo  <xinguo.li@zilliz.com>
issue: #374 

**What I had done**
    I added the file, Utils.h and Utils.cpp under the common folder. It invokes two functions to control the omp threads when build and query for all indexes we will use in the future. 
    The default parameters were set by omp_get_max_num() at the beginning.
    At the function that may reduce multithreading problems in all indexes, it invokes SetXxxOmpThread() to control threads. You can set the value by adding the strings in config.

