### PR TITLE
Substitute OpenBLAS for MKL in DiskANN

### DIFF
--- a/cmake/ThirdPartyPackagesKw.cmake
+++ b/cmake/ThirdPartyPackagesKw.cmake
@@ -20,18 +20,6 @@ if ( LINUX AND KNOWHERE_WITH_DISKANN)
         ${KNOWHERE_THIRDPARTY_DEPENDENCIES}
         DiskANN
         )
-    # For Ubuntu 18.04 (install MKL by script)
-    set(MKL_ROOT "/opt/intel/oneapi/mkl/latest")
-    set(OMP_PATH "/opt/intel/oneapi/compiler/2022.0.2/linux/compiler/lib/intel64_lin/")
-    include_directories(${MKL_ROOT}/include)
-    link_directories(${OMP_PATH} ${MKL_ROOT}/lib/intel64)
-
-    # For Ubuntu 20.04/22.04 (install MKL by apt)
-    link_directories(/usr/lib/x86_64-linux-gnu/mkl)
-    include_directories(/usr/include/mkl)
-
-    set(MKL_LIBRARIES mkl_intel_ilp64 mkl_intel_thread mkl_core iomp5 pthread m dl )
-    message( STATUS "MKL RELATED LIBRARIES: ${MKL_LIBRARIES}")
 endif()
 
 message(STATUS "Using ${KNOWHERE_DEPENDENCY_SOURCE} approach to find dependencies")

--- a/knowhere/CMakeLists.txt
+++ b/knowhere/CMakeLists.txt
@@ -164,7 +164,6 @@ if (KNOWHERE_WITH_DISKANN)
              ${depend_libs}
              diskann
              aio
-             ${MKL_LIBRARIES}
              )
 endif()
 

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -37,7 +37,6 @@ if [[ "${MACHINE}" == "Linux" ]]; then
         sudo apt install -y g++ gcc make ccache python3-dev gfortran
         if [ "$release_num" == "20.04" ];then
             sudo apt install -y python3-setuptools swig
-            sudo apt install libmkl-full-dev
         fi
         # Pre-installation of openblas can save about 15 minutes of openblas building time.
         # But the apt-installed openblas version is 0.2.20, while the latest openblas version is 0.3.19.
@@ -48,8 +47,6 @@ if [[ "${MACHINE}" == "Linux" ]]; then
         #DiskANN dependencies
         sudo apt-get install -y libboost-program-options-dev
         sudo apt-get install -y libaio-dev libgoogle-perftools-dev clang-format
-        wget https://registrationcenter-download.intel.com/akdlm/irc_nas/18487/l_BaseKit_p_2022.1.2.146.sh
-        sudo sh l_BaseKit_p_2022.1.2.146.sh -a --components intel.oneapi.lin.mkl.devel --action install --eula accept -s
     elif [[ -x "$(command -v yum)" ]]; then
         # for CentOS 7
         sudo yum install -y epel-release centos-release-scl-rh wget && \
@@ -64,8 +61,6 @@ if [[ "${MACHINE}" == "Linux" ]]; then
         #DiskANN dependencies
         sudo yum -y install boost-program-options
         sudo yum -y install boost libaio gperftools-devel 
-        sudo yum-config-manager --add-repo https://yum.repos.intel.com/mkl/setup/intel-mkl.repo
-        sudo yum install -y intel-mkl 
         #CMake 3.18 or higher is required
         wget -c https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2-linux-x86_64.tar.gz && \
         tar -zxvf cmake-3.22.2-linux-x86_64.tar.gz && \

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -156,7 +156,7 @@ macro(build_diskann)
             "-DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}"
             "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}"
             "-DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}"
-            "-DCMAKE_CXX_FLAGS=-O3 -DELPP_THREAD_SAFE -fpermissive -I ${KNOWHERE_SOURCE_DIR} -I ${KNOWHERE_SOURCE_DIR}/thirdparty"
+            "-DCMAKE_CXX_FLAGS=-O3 -DELPP_THREAD_SAFE -fpermissive -I ${KNOWHERE_SOURCE_DIR} -I ${KNOWHERE_SOURCE_DIR}/thirdparty -I ${KNOWHERE_SOURCE_DIR}/output/include"       
             )
     message( STATUS "Building DISKANN with configure args -${DISKANN_CMAKE_ARGS}" )
     set( DISKANN_BUILD_DIR "${DISKANN_SOURCE_DIR}/build")
@@ -173,15 +173,20 @@ macro(build_diskann)
         ${DISKANN_STATIC_LIB} 
         BUILD_ALWAYS 1)
 
+        if ( NOT BLAS_FOUND )
+            message( STATUS "OpenBLAS BOUNDED" )
+            ExternalProject_Add_StepDependencies( diskann_ep configure openblas_ep knowhere_utils )
+        endif()
+
         add_library( diskann STATIC IMPORTED )
-       
+
         set_target_properties( diskann
         PROPERTIES
             IMPORTED_GLOBAL                 TRUE
             IMPORTED_LOCATION               "${DISKANN_STATIC_LIB}"
             INTERFACE_INCLUDE_DIRECTORIES   "${DISKANN_INCLUDE_DIR}")
 
-        target_link_libraries( diskann INTERFACE knowhere_utils )
+        target_link_libraries( diskann INTERFACE knowhere_utils openblas )
         add_dependencies( diskann diskann_ep )
 endmacro()
 

--- a/thirdparty/DiskANN/CMakeLists.txt
+++ b/thirdparty/DiskANN/CMakeLists.txt
@@ -131,21 +131,9 @@ if (MSVC)
         "${DISKANN_MKL_LIB_PATH}/mkl_intel_thread.lib")
 else()
 	# expected path for manual intel mkl installs
-	set(OMP_PATH /opt/intel/oneapi/compiler/2022.0.2/linux/compiler/lib/intel64_lin/ CACHE PATH "Intel OneAPI OpenMP library implementation path")
-	set(MKL_ROOT /opt/intel/oneapi/mkl/latest CACHE PATH "Intel OneAPI MKL library implementation path")
-	link_directories(${OMP_PATH} ${MKL_ROOT}/lib/intel64)
-	include_directories(${MKL_ROOT}/include)
-
-	# expected path for apt packaged intel mkl installs
-	link_directories(/usr/lib/x86_64-linux-gnu/mkl)
-	include_directories(/usr/include/mkl)
-
-	# compile flags and link libraries
-        add_compile_options(-m64 -Wl,--no-as-needed) 
-	link_libraries(mkl_intel_ilp64 mkl_intel_thread mkl_core iomp5 pthread m dl)
+	
+    link_libraries( openblas ${CMAKE_INSTALL_PREFIX}/lib )
 endif()
-
-add_definitions(-DMKL_ILP64)
 
 # Section for tcmalloc. The DiskANN tools are always linked to tcmalloc. For Windows, they also need to
 # force-include the _tcmalloc symbol for enabling tcmalloc.

--- a/thirdparty/DiskANN/src/aux_utils.cpp
+++ b/thirdparty/DiskANN/src/aux_utils.cpp
@@ -18,7 +18,7 @@
 #include "aux_utils.h"
 #include "cached_io.h"
 #include "index.h"
-#include "mkl.h"
+#include "openblas/cblas.h"
 #include "omp.h"
 #include "partition_and_pq.h"
 #include "percentile_stats.h"
@@ -983,7 +983,6 @@ namespace diskann {
 
     if (num_threads != 0) {
       omp_set_num_threads(num_threads);
-      mkl_set_num_threads(num_threads);
     }
 
     LOG(INFO) << "Starting index build: R=" << R << " L=" << L

--- a/thirdparty/DiskANN/src/math_utils.cpp
+++ b/thirdparty/DiskANN/src/math_utils.cpp
@@ -5,7 +5,7 @@
 #include <unordered_set>
 #include <malloc.h>
 #include <math_utils.h>
-#include <mkl.h>
+#include "openblas/cblas.h"
 #include "logger.h"
 #include "utils.h"
 
@@ -27,7 +27,7 @@ namespace math_utils {
 #pragma omp parallel for schedule(static, 8192)
     for (int64_t n_iter = 0; n_iter < (_s64) num_points; n_iter++) {
       vecs_l2sq[n_iter] =
-          cblas_snrm2((MKL_INT) dim, (data + (n_iter * dim)), 1);
+          cblas_snrm2(dim, (data + (n_iter * dim)), 1);
       vecs_l2sq[n_iter] *= vecs_l2sq[n_iter];
     }
   }
@@ -42,9 +42,9 @@ namespace math_utils {
     }
     diskann::cout << "done Rotating data with random matrix.." << std::flush;
 
-    cblas_sgemm(CblasRowMajor, CblasNoTrans, transpose, (MKL_INT) num_points,
-                (MKL_INT) dim, (MKL_INT) dim, 1.0, data, (MKL_INT) dim, rot_mat,
-                (MKL_INT) dim, 0, new_mat, (MKL_INT) dim);
+    cblas_sgemm(CblasRowMajor, CblasNoTrans, transpose,  num_points,
+                 dim,  dim, 1.0, data,  dim, rot_mat,
+                 dim, 0, new_mat,  dim);
 
     diskann::cout << "done." << std::endl;
   }
@@ -80,20 +80,20 @@ namespace math_utils {
       ones_b[i] = 1.0;
     }
 
-    cblas_sgemm(CblasRowMajor, CblasNoTrans, CblasTrans, (MKL_INT) num_points,
-                (MKL_INT) num_centers, (MKL_INT) 1, 1.0f, docs_l2sq,
-                (MKL_INT) 1, ones_a, (MKL_INT) 1, 0.0f, dist_matrix,
-                (MKL_INT) num_centers);
+    cblas_sgemm(CblasRowMajor, CblasNoTrans, CblasTrans,  num_points,
+                 num_centers,  1, 1.0f, docs_l2sq,
+                 1, ones_a,  1, 0.0f, dist_matrix,
+                 num_centers);
 
-    cblas_sgemm(CblasRowMajor, CblasNoTrans, CblasTrans, (MKL_INT) num_points,
-                (MKL_INT) num_centers, (MKL_INT) 1, 1.0f, ones_b, (MKL_INT) 1,
-                centers_l2sq, (MKL_INT) 1, 1.0f, dist_matrix,
-                (MKL_INT) num_centers);
+    cblas_sgemm(CblasRowMajor, CblasNoTrans, CblasTrans,  num_points,
+                 num_centers,  1, 1.0f, ones_b,  1,
+                centers_l2sq,  1, 1.0f, dist_matrix,
+                 num_centers);
 
-    cblas_sgemm(CblasRowMajor, CblasNoTrans, CblasTrans, (MKL_INT) num_points,
-                (MKL_INT) num_centers, (MKL_INT) dim, -2.0f, data,
-                (MKL_INT) dim, centers, (MKL_INT) dim, 1.0f, dist_matrix,
-                (MKL_INT) num_centers);
+    cblas_sgemm(CblasRowMajor, CblasNoTrans, CblasTrans,  num_points,
+                 num_centers,  dim, -2.0f, data,
+                 dim, centers,  dim, 1.0f, dist_matrix,
+                 num_centers);
 
     if (k == 1) {
 #pragma omp parallel for schedule(static, 8192)


### PR DESCRIPTION
Signed-off-by: matchyc <dawnlight.yc@protonmail.com>
issue: #253 
To control the behaviors of DiskANN, we need to substitute OenBlas for mkl in DiskANN.
Also, remove MKL-related codes.