### PR TITLE
Limit the Diskann cached nodes number

### DIFF
--- a/knowhere/index/vector_index/IndexDiskANN.cpp
+++ b/knowhere/index/vector_index/IndexDiskANN.cpp
@@ -271,6 +271,9 @@ IndexDiskANN<T>::Prepare(const Config& config) {
 
     std::string warmup_query_file = diskann::get_sample_data_filename(index_prefix_);
     // load cache
+    if (prep_conf.num_nodes_to_cache > pq_flash_index_->get_num_points() / 3) {
+        KNOWHERE_THROW_MSG("Failed to generate cache, num_nodes_to_cache is larger than 1/3 of the total data number.");
+    }
     if (prep_conf.num_nodes_to_cache > 0) {
         std::vector<uint32_t> node_list;
         LOG_KNOWHERE_INFO_ << "Caching " << prep_conf.num_nodes_to_cache << " sample nodes around medoid(s).";

--- a/thirdparty/DiskANN/src/pq_flash_index.cpp
+++ b/thirdparty/DiskANN/src/pq_flash_index.cpp
@@ -350,16 +350,6 @@ namespace diskann {
 
     node_list.clear();
 
-    // Do not cache more than 10% of the nodes in the index
-    _u64 tenp_nodes = (_u64)(std::round(this->num_points * 0.1));
-    if (num_nodes_to_cache > tenp_nodes) {
-      LOG(INFO) << "Reducing nodes to cache from: " << num_nodes_to_cache
-                    << " to: " << tenp_nodes
-                    << "(10 percent of total nodes:" << this->num_points << ")";
-      num_nodes_to_cache = tenp_nodes == 0 ? 1 : tenp_nodes;
-    }
-    LOG(INFO) << "Caching " << num_nodes_to_cache << "...";
-
     // borrow thread data
     ThreadData<T> this_thread_data = this->thread_data.pop();
     while (this_thread_data.scratch.sector_scratch == nullptr) {

--- a/unittest/test_diskann.cpp
+++ b/unittest/test_diskann.cpp
@@ -733,3 +733,14 @@ TEST_P(DiskANNTest, build_config_test) {
     fs::remove_all(test_dir);
     fs::remove(test_dir);
 }
+
+TEST_P(DiskANNTest, generate_cache_list_test) {
+    knowhere::Config cfg;
+    uint32_t cached_nodes_num = kNumRows * 10;
+    knowhere::DiskANNPrepareConfig prep_conf_to_test = prep_conf;
+    prep_conf_to_test.use_bfs_cache = false;
+    prep_conf_to_test.num_nodes_to_cache = cached_nodes_num;
+
+    knowhere::DiskANNPrepareConfig::Set(cfg, prep_conf_to_test);
+    EXPECT_THROW(diskann->Prepare(cfg), knowhere::KnowhereException);
+}


### PR DESCRIPTION
Signed-off-by: cqy123456 <yaya645@126.com>

issue: #253 

1.  The number of caches does not exceed 1/3 of the total data size;
2. Remove the code for cache resizing in cache_bfs_levels().