### PR TITLE
Modify clang-tidy according our style

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -20,7 +20,7 @@ Checks: >
     -*, clang-diagnostic-*, -clang-diagnostic-error,
     clang-analyzer-*, -clang-analyzer-alpha*,
     google-*, -google-runtime-references, -google-readability-todo,
-    modernize-*, -modernize-pass-by-value, -modernize-use-equals-default,
+    modernize-*, -modernize-pass-by-value, -modernize-use-equals-default, -modernize-use-trailing-return-type
     performance-faster-string-find, performance-for-range-copy,
     performance-implicit-conversion-in-loop, performance-inefficient-algorithm,
     performance-trivially-destructible, performance-inefficient-vector-operation,
@@ -33,8 +33,6 @@ Checks: >
 HeaderFilterRegex: '^?!(.*cmake-build-debug.*|.*cmake-build-release.*|.*cmake_build.*|.*thirdparty.*|.*src/grpc.*|.*knowhere/include.*|.*unittest.*)$'
 AnalyzeTemporaryDtors: true
 CheckOptions:
-  - key:             google-readability-braces-around-statements.ShortStatementLines
-    value:           '1'
   - key:             google-readability-function-size.StatementThreshold
     value:           '800'
   - key:             google-readability-namespace-comments.ShortNamespaceLines


### PR DESCRIPTION
Signed-off-by: liliu-z <li.liu@zilliz.com>

Clang Tidy List: https://clang.llvm.org/extra/clang-tidy/checks/list.html

1. Remove trailing-return-type check
2. check braces usage for all cases including 1 line.