### PR TITLE
Add default values to diskann parameters

### DIFF
--- a/knowhere/index/vector_index/IndexDiskANNConfig.h
+++ b/knowhere/index/vector_index/IndexDiskANNConfig.h
@@ -22,12 +22,12 @@ struct DiskANNBuildConfig {
     std::string data_path;
     // This is the degree of the graph index, typically between 60 and 150. Larger R will result in larger indices and
     // longer indexing times, but better search quality.
-    uint32_t max_degree;
+    uint32_t max_degree = 48;
     // The size of the search list during the index build. Typical values are between 75 to 200. Larger values will take
     // more time to build but result in indices that provide higher recall for the same search complexity. Plz set this
     // value larger than the max_degree unless you need to build indices really quickly and can somewhat compromise on
     // quality.
-    uint32_t search_list_size;
+    uint32_t search_list_size = 128;
     // Limit the size of the PQ code after the raw vector has been PQ-encoded. PQ code is (a search_list_size / row_num
     // )-dimensional uint8 vector. If pq_code_budget_gb is too large, it will be adjusted to the size of dim*row_num.
     float pq_code_budget_gb;
@@ -35,18 +35,18 @@ struct DiskANNBuildConfig {
     // build the index in one pass, the index is built using a divide and conquer approach so that sub-graphs will fit
     // in the RAM budget. The sub-graphs are overlayed to build the overall index. This approach can be up to 1.5 times
     // slower than building the index in one shot. Allocate as much memory as your RAM allows.
-    float build_dram_budget_gb;
+    float build_dram_budget_gb = 16;
     // Number of threads used by the index build process. Since the code is highly parallel, the indexing time improves
     // almost linearly with the number of threads (subject to the cores available on the machine and DRAM bandwidth).
-    uint32_t num_threads;
+    uint32_t num_threads = 8;
     // Use 0 to store uncompressed data on SSD. This allows the index to asymptote to 100% recall. If your vectors are
     // too large to store in SSD, this parameter provides the option to compress the vectors using PQ for storing on
     // SSD. This will trade off the recall. You would also want this to be greater than the number of bytes used for the
     // PQ compressed data stored in-memory
-    uint32_t disk_pq_dims;
+    uint32_t disk_pq_dims = 0;
     // This is the flag to enable fast build, in which we will not build vamana graph by full 2 round. This can
     // accelerate index build ~30% with an ~1% recall regression.
-    bool accelerate_build;
+    bool accelerate_build = false;
 
     static DiskANNBuildConfig
     Get(const Config& config);
@@ -60,16 +60,16 @@ struct DiskANNPrepareConfig {
     // at a time. More threads will result in higher aggregate query throughput, but will also use more IOs/second
     // across the system, which may lead to higher per-query latency. So find the balance depending on the maximum
     // number of IOPs supported by the SSD.
-    uint32_t num_threads;
+    uint32_t num_threads = 8;
     // While serving the index, the entire graph is stored on SSD. For faster search performance, you can cache a few
     // frequently accessed nodes in memory.
-    float search_cache_budget_gb;
+    float search_cache_budget_gb = 0;
     // Should we do warm-up before searching.
-    bool warm_up;
+    bool warm_up = false;
     // Should we use the bfs strategy to cache. We have two cache strategies: 1. use sample queries to do searches and
     // cached the nodes on the search paths; 2. do bfs from the entry point and cache them. The first method is suitable
     // for TopK query heavy circumstances and the second one performed better in range search.
-    bool use_bfs_cache;
+    bool use_bfs_cache = false;
     // The numebr of maximum parallel disk reads per thread. It should be set linearly proportional to `beam_width`.
     // Suggested ratio of this and `beam_width` is 2:1.
     // On Linux, the default limit of `aio-max-nr` is 65536, so the product of `num_threads` and `aio_maxnr` should
@@ -94,7 +94,7 @@ struct DiskANNQueryConfig {
     // iteration of search code. Larger beamwidth will result in fewer IO round-trips per query but might result in
     // slightly higher total number of IO requests to SSD per query. For the highest query throughput with a fixed SSD
     // IOps rating, use W=1. For best latency, use W=4,8 or higher complexity search.
-    uint32_t beamwidth;
+    uint32_t beamwidth = 8;
 
     static DiskANNQueryConfig
     Get(const Config& config);
@@ -106,11 +106,11 @@ struct DiskANNQueryConfig {
 struct DiskANNQueryByRangeConfig {
     float radius;
     // DiskANN uses TopK search to simulate range search by double the K in every round. This is the start K.
-    uint64_t min_k;
+    uint64_t min_k = 100;
     // DiskANN uses TopK search to simulate range search by double the K in every round. This is the largest K.
-    uint64_t max_k;
+    uint64_t max_k = 10000;
     // Beamwidth used for TopK search.
-    uint32_t beamwidth;
+    uint32_t beamwidth = 8;
     // DiskANN uses TopK search to simulate range search, this is the ratio of search list size and k. With larger
     // ratio, the accuracy will get higher but throughput will get affected.
     float search_list_and_k_ratio = 2;


### PR DESCRIPTION
Signed-off-by: cqy123456 <yaya645@126.com>
Add default value to diskann parameters. The default values ​​of all parameters are as follows:
DiskANNBuildConfig ：
    data_path(none)
    max_degree(48)
    search_list_size(128)
    pq_code_budget_gb(none)
    build_dram_budget_gb(16G)
    num_threads(omp_get_num_procs() or 8)
   disk_pq_dims(0)
   accelerate_build(false)

DiskANNPrepareConfig：
    num_threads(omp_get_num_procs() or 8)
    float search_cache_budget_gb(0)
    bool warm_up(false)
    bool use_bfs_cache(false)
    aio_maxnr(32)

DiskANNQueryConfig：
    k(none)
    search_list_size(topk)
    beamwidth(8)

DiskANNQueryByRangeConfig：
    radius(0)
    min_k(100)
    max_k(100000)
    beamwidth(8)
    search_list_and_k_ratio(2)