### PR TITLE
Make Num/Count available right after build

### DIFF
--- a/knowhere/index/vector_index/IndexDiskANN.h
+++ b/knowhere/index/vector_index/IndexDiskANN.h
@@ -13,6 +13,7 @@
 
 #include <memory>
 #include <string>
+#include <atomic>
 
 #include "DiskANN/include/pq_flash_index.h"
 #include "knowhere/common/FileManager.h"
@@ -108,9 +109,11 @@ class IndexDiskANN : public VecIndex {
 
     std::unique_ptr<diskann::PQFlashIndex<T>> pq_flash_index_;
 
-    bool is_prepared_ = false;
+    std::atomic_bool is_prepared_ = false;
     int32_t num_threads_ = 0;
     std::mutex preparation_lock_;
+    std::atomic_int64_t dim_ = -1;
+    std::atomic_int64_t count_ = -1;
 };
 
 }  // namespace knowhere

--- a/unittest/test_diskann.cpp
+++ b/unittest/test_diskann.cpp
@@ -363,6 +363,18 @@ TEST_P(DiskANNTest, bitset_view_test) {
     EXPECT_GT(recall, 0.5);
 }
 
+TEST_P(DiskANNTest, meta_test) {
+    EXPECT_THROW(diskann->Dim(), knowhere::KnowhereException);
+    EXPECT_THROW(diskann->Count(), knowhere::KnowhereException);
+
+    knowhere::Config cfg;
+    knowhere::DiskANNPrepareConfig::Set(cfg, prep_conf);
+    EXPECT_TRUE(diskann->Prepare(cfg));
+
+    EXPECT_EQ(kDim, diskann->Dim());
+    EXPECT_EQ(kNumRows, diskann->Count());
+}
+
 TEST_P(DiskANNTest, knn_search_test) {
     knowhere::Config cfg;
     knowhere::DiskANNQueryConfig::Set(cfg, query_conf);
@@ -405,6 +417,9 @@ TEST_P(DiskANNTest, knn_search_with_accelerate_build_test) {
     accelerate_build_conf.accelerate_build = true;
     knowhere::DiskANNBuildConfig::Set(cfg, accelerate_build_conf);
     accelerate_diskann->BuildAll(nullptr, cfg);
+
+    EXPECT_EQ(kDim, accelerate_diskann->Dim());
+    EXPECT_EQ(kNumRows, accelerate_diskann->Count());
 
     // prepare
     cfg.clear();


### PR DESCRIPTION
Signed-off-by: liliu-z <li.liu@zilliz.com>

issue: #253 

This change make DiskANN's dim/count can be gotten right after build. Perform the same as other indexes.