### PR TITLE
Support metric IP for diskann range search

### DIFF
--- a/knowhere/index/vector_index/IndexDiskANN.cpp
+++ b/knowhere/index/vector_index/IndexDiskANN.cpp
@@ -406,10 +406,6 @@ IndexDiskANN<T>::Query(const DatasetPtr& dataset_ptr, const Config& config, cons
 template <typename T>
 DatasetPtr
 IndexDiskANN<T>::QueryByRange(const DatasetPtr& dataset_ptr, const Config& config, const faiss::BitsetView bitset) {
-    // TODO: the IP distance is negative in all cases now, need to fix it.
-    if (metric_ == diskann::INNER_PRODUCT) {
-        KNOWHERE_THROW_MSG("DiskANN doesn't support QueryByRange for IP now.");
-    }
     CheckPreparation(is_prepared_.load());
 
     // set thread number


### PR DESCRIPTION
Signed-off-by: cqy123456 <yaya645@126.com>
Diskann uses L2 metirc to caculate IP distance, we can convert the result to the origin ip distance by this formula：
<img width="250" alt="image" src="https://user-images.githubusercontent.com/39671710/194753750-7afbdd70-01ae-47b8-a15e-8ecbd5f9b57e.png">
issue: https://github.com/milvus-io/knowhere/issues/253
