### PR TITLE
Pass CMAKE_PREFIX_PATH to externla project

### DIFF
--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -151,6 +151,7 @@ macro(build_diskann)
             "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}"
             "-DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}"
             "-DCMAKE_CXX_FLAGS=-O3 -DELPP_THREAD_SAFE -fpermissive -I ${KNOWHERE_SOURCE_DIR} -I ${KNOWHERE_SOURCE_DIR}/thirdparty -I ${CMAKE_INSTALL_PREFIX}/include"       
+            "-DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}"
             )
     message( STATUS "Building DISKANN with configure args -${DISKANN_CMAKE_ARGS}" )
     set( DISKANN_BUILD_DIR "${DISKANN_SOURCE_DIR}/build")


### PR DESCRIPTION
Signed-off-by: Enwei Jiao <enwei.jiao@zilliz.com>
issue: https://github.com/milvus-io/milvus/issues/19806

I want to try using `conan` as a package manager in milvus.  The boost package cannot be found in that case, after passing `CMAKE_PREFIX_PATH` to DiskANN's CMake args everything works fine