### PR TITLE
Make the Query thread pool global

### DIFF
--- a/.github/workflows/ut.yaml
+++ b/.github/workflows/ut.yaml
@@ -112,6 +112,3 @@ jobs:
         shell: msys2 {0}
         run: |
           ./build.sh -t Release -u
-          cp -fr output/lib/*.dll output/unittest/
-          ./output/unittest/faiss_test
-          ./output/unittest/test_knowhere

--- a/knowhere/CMakeLists.txt
+++ b/knowhere/CMakeLists.txt
@@ -26,6 +26,7 @@ set(external_srcs
         common/Exception.cpp
         common/Timer.cpp
         common/Log.cpp
+        common/ThreadPoolHolder.cpp
         ${KNOWHERE_THIRDPARTY_SRC}/easyloggingpp/easylogging++.cc
         )
 

--- a/knowhere/common/ThreadPoolHolder.cpp
+++ b/knowhere/common/ThreadPoolHolder.cpp
@@ -1,0 +1,47 @@
+// Copyright (C) 2019-2020 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under the License
+
+#include "knowhere/common/ThreadPoolHolder.h"
+
+#include "knowhere/common/Log.h"
+
+namespace knowhere {
+
+void
+ThreadPoolHolder::Init(uint32_t num_threads) {
+    if (!pool_) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (!pool_) {
+            pool_ = std::make_shared<ctpl::thread_pool>(num_threads);
+        }
+    }
+    LOG_KNOWHERE_WARNING_ << "ThreadPoolHolder has already been initilaized with threads num: " << pool_->size();
+}
+
+std::shared_ptr<ctpl::thread_pool>
+ThreadPoolHolder::GetThreadPool() {
+    if (!pool_) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (!pool_) {
+            LOG_KNOWHERE_WARNING_ << "ThreadPoolHolder is not inialized, init it with threads num: "
+                                  << std::thread::hardware_concurrency();
+            pool_ = std::make_shared<ctpl::thread_pool>(std::thread::hardware_concurrency());
+        }
+    }
+    return pool_;
+}
+
+ThreadPoolHolder&
+ThreadPoolHolder::GetInstance() {
+    static ThreadPoolHolder holder;
+    return holder;
+}
+}  // namespace knowhere

--- a/knowhere/common/ThreadPoolHolder.h
+++ b/knowhere/common/ThreadPoolHolder.h
@@ -1,0 +1,47 @@
+// Copyright (C) 2019-2020 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under the License
+
+#pragma once
+
+#include <memory>
+#include <mutex>
+
+#include "ctpl/ctpl-std.h"
+namespace knowhere {
+
+class ThreadPoolHolder {
+ public:
+    ThreadPoolHolder(const ThreadPoolHolder&) = delete;
+
+    ThreadPoolHolder&
+    operator=(const ThreadPoolHolder&) = delete;
+
+    ThreadPoolHolder(ThreadPoolHolder&&) noexcept = delete;
+
+    ThreadPoolHolder&
+    operator=(ThreadPoolHolder&&) noexcept = delete;
+
+    void
+    Init(uint32_t num_threads);
+
+    std::shared_ptr<ctpl::thread_pool>
+    GetThreadPool();
+
+    static ThreadPoolHolder&
+    GetInstance();
+
+ private:
+    ThreadPoolHolder() = default;
+
+    std::shared_ptr<ctpl::thread_pool> pool_;
+    std::mutex mutex_;
+};
+}  // namespace knowhere

--- a/knowhere/index/vector_index/IndexHNSW.h
+++ b/knowhere/index/vector_index/IndexHNSW.h
@@ -14,9 +14,9 @@
 #include <memory>
 #include <unordered_set>
 
-#include "ctpl/ctpl-std.h"
 #include "hnswlib/hnswlib/hnswlib.h"
 #include "knowhere/common/Exception.h"
+#include "knowhere/common/ThreadPoolHolder.h"
 #include "knowhere/feder/HNSW.h"
 #include "knowhere/index/VecIndex.h"
 
@@ -24,13 +24,10 @@ namespace knowhere {
 
 class IndexHNSW : public VecIndex {
  public:
-    IndexHNSW() : IndexHNSW(std::thread::hardware_concurrency()) {
-    }
-
-    explicit IndexHNSW(uint32_t num_threads) {
+    IndexHNSW() {
         index_type_ = IndexEnum::INDEX_HNSW;
         stats = std::make_shared<LibHNSWStatistics>(index_type_);
-        pool_ = std::make_unique<ctpl::thread_pool>(num_threads);
+        pool_ = ThreadPoolHolder::GetInstance().GetThreadPool();
     }
 
     IndexHNSW(const IndexHNSW& index_hnsw) = delete;
@@ -89,7 +86,7 @@ class IndexHNSW : public VecIndex {
     UpdateLevelLinkList(int32_t, feder::hnsw::HNSWMeta&, std::unordered_set<int64_t>&);
 
  private:
-    std::unique_ptr<ctpl::thread_pool> pool_;
+    std::shared_ptr<ctpl::thread_pool> pool_;
     std::unique_ptr<hnswlib::HierarchicalNSW<float>> index_;
 };
 


### PR DESCRIPTION
Signed-off-by: liliu-z <li.liu@zilliz.com>

This is PR is to make the thread pool global and shared by different segment in one query node. 

We did a test on 2C8G container with 6M SIFT data, which is 8 segments. The improvement of serial/parallel execution is about ~10-15%

issue: #513 