### PR TITLE
Decouple thread id and aio context id

### DIFF
--- a/knowhere/archive/KnowhereConfig.cpp
+++ b/knowhere/archive/KnowhereConfig.cpp
@@ -9,15 +9,19 @@
 // is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 // or implied. See the License for the specific language governing permissions and limitations under the License.
 
+#include "archive/KnowhereConfig.h"
+
 #include <string>
 
-#include "archive/KnowhereConfig.h"
 #include "common/Log.h"
-#include "index/vector_index/Statistics.h"
 #include "faiss/Clustering.h"
 #include "faiss/FaissHook.h"
 #include "faiss/utils/distances.h"
 #include "faiss/utils/utils.h"
+#include "index/vector_index/Statistics.h"
+#ifdef KNOWHERE_WITH_DISKANN
+#include "DiskANN/include/aio_context_pool.h"
+#endif
 #ifdef KNOWHERE_GPU_VERSION
 #include "knowhere/index/vector_index/helpers/FaissGpuResourceMgr.h"
 #endif
@@ -126,6 +130,13 @@ KnowhereConfig::FreeGPUResource() {
 #ifdef KNOWHERE_GPU_VERSION
     LOG_KNOWHERE_INFO_ << "free GPU resource";
     knowhere::FaissGpuResourceMgr::GetInstance().Free();  // Release gpu resources.
+#endif
+}
+
+void
+KnowhereConfig::SetAioContextPool(size_t num_ctx, size_t max_events) {
+#ifdef KNOWHERE_WITH_DISKANN
+    AioContextPool::InitGlobalAioPool(num_ctx, max_events);
 #endif
 }
 

--- a/knowhere/archive/KnowhereConfig.h
+++ b/knowhere/archive/KnowhereConfig.h
@@ -90,6 +90,9 @@ class KnowhereConfig {
      */
     static void
     FreeGPUResource();
+
+    static void
+    SetAioContextPool(size_t num_ctx, size_t max_events);
 };
 
 }  // namespace knowhere

--- a/knowhere/index/vector_index/IndexDiskANN.cpp
+++ b/knowhere/index/vector_index/IndexDiskANN.cpp
@@ -243,7 +243,7 @@ IndexDiskANN<T>::Prepare(const Config& config) {
 #ifdef _WINDOWS
     reader.reset(new WindowsAlignedFileReader());
 #else
-    reader.reset(new LinuxAlignedFileReader(prep_conf.aio_maxnr));
+    reader.reset(new LinuxAlignedFileReader());
 #endif
 
     pq_flash_index_ = std::make_unique<diskann::PQFlashIndex<T>>(reader, metric_);

--- a/thirdparty/DiskANN/include/aio_context_pool.h
+++ b/thirdparty/DiskANN/include/aio_context_pool.h
@@ -1,0 +1,70 @@
+#pragma once
+
+#ifndef _WINDOWS
+
+#include <mutex>
+#include <queue>
+#include <libaio.h>
+#include <condition_variable>
+#include "utils.h"
+#include "concurrent_queue.h"
+
+class AioContextPool {
+ public:
+  AioContextPool(const AioContextPool&) = delete;
+
+  AioContextPool& operator=(const AioContextPool&) = delete;
+
+  AioContextPool(AioContextPool&&) noexcept = delete;
+
+  AioContextPool& operator==(AioContextPool&&) noexcept = delete;
+
+  size_t max_events_per_ctx() {
+    return max_events_;
+  }
+
+  void push(io_context_t ctx) {
+    {
+      std::scoped_lock lk(ctx_mtx_);
+      ctx_q_.push(ctx);
+    }
+    ctx_cv_.notify_one();
+  }
+
+  io_context_t pop() {
+    std::unique_lock lk(ctx_mtx_);
+    ctx_cv_.wait(lk, [this] { return ctx_q_.size(); });
+    if (stop_) {
+      return nullptr;
+    }
+    auto ret = ctx_q_.front();
+    ctx_q_.pop();
+    return ret;
+  }
+
+  static void InitGlobalAioPool(size_t num_ctx, size_t max_events);
+
+  static std::shared_ptr<AioContextPool> GetGlobalAioPool();
+
+  ~AioContextPool() {
+    for (size_t i = 0; i < num_ctx_; ++i) {
+      auto ctx = pop();
+      io_destroy(ctx);
+    }
+    std::scoped_lock lk(ctx_mtx_);
+    ctx_cv_.notify_all();
+    stop_ = true;
+  }
+
+ private:
+  std::queue<io_context_t> ctx_q_;
+  std::mutex               ctx_mtx_;
+  std::condition_variable  ctx_cv_;
+  bool                     stop_ = false;
+  size_t                   num_ctx_;
+  size_t                   max_events_;
+
+  AioContextPool(size_t num_ctx, size_t max_events);
+};
+
+#endif

--- a/thirdparty/DiskANN/include/aligned_file_reader.h
+++ b/thirdparty/DiskANN/include/aligned_file_reader.h
@@ -80,17 +80,11 @@ class AlignedFileReader {
   std::mutex                                 ctx_mut;
 
  public:
-  // returns the thread-specific context
-  // returns (io_context_t)(-1) if thread is not registered
-  virtual IOContext& get_ctx() = 0;
-
   virtual ~AlignedFileReader(){};
 
-  // register thread-id for a context
-  virtual void register_thread() = 0;
-  // de-register thread-id for a context
-  virtual void deregister_thread() = 0;
-  virtual void deregister_all_threads() = 0;
+  virtual IOContext get_ctx() = 0;
+
+  virtual void put_ctx(IOContext) = 0;
 
   // Open & close ops
   // Blocking calls

--- a/thirdparty/DiskANN/include/linux_aligned_file_reader.h
+++ b/thirdparty/DiskANN/include/linux_aligned_file_reader.h
@@ -5,27 +5,27 @@
 #ifndef _WINDOWS
 
 #include "aligned_file_reader.h"
+#include "aio_context_pool.h"
 
 class LinuxAlignedFileReader : public AlignedFileReader {
  private:
   uint64_t     file_sz;
   FileHandle   file_desc;
   io_context_t bad_ctx = (io_context_t) -1;
-  uint64_t     maxnr;
+
+  std::shared_ptr<AioContextPool> ctx_pool_;
 
  public:
-  LinuxAlignedFileReader(uint64_t maxnr);
+  LinuxAlignedFileReader();
   ~LinuxAlignedFileReader();
 
-  IOContext &get_ctx();
+  io_context_t get_ctx() {
+    return ctx_pool_->pop();
+  }
 
-  // register thread-id for a context
-  void register_thread();
-
-  // de-register thread-id for a context
-  void deregister_thread();
-  void deregister_all_threads();
-
+  void put_ctx(io_context_t ctx) {
+    ctx_pool_->push(ctx);
+  }
 
   // Open & close ops
   // Blocking calls
@@ -34,7 +34,7 @@ class LinuxAlignedFileReader : public AlignedFileReader {
 
   // process batch of aligned requests in parallel
   // NOTE :: blocking call
-  void read(std::vector<AlignedRead> &read_reqs, IOContext &ctx,
+  void read(std::vector<AlignedRead> &read_reqs, IOContext& ctx,
             bool async = false);
 };
 

--- a/thirdparty/DiskANN/include/pq_flash_index.h
+++ b/thirdparty/DiskANN/include/pq_flash_index.h
@@ -55,7 +55,6 @@ namespace diskann {
   template<typename T>
   struct ThreadData {
     QueryScratch<T> scratch;
-    IOContext       ctx;
   };
 
   template<typename T>

--- a/thirdparty/DiskANN/include/windows_aligned_file_reader.h
+++ b/thirdparty/DiskANN/include/windows_aligned_file_reader.h
@@ -34,13 +34,10 @@ class WindowsAlignedFileReader : public AlignedFileReader {
   DISKANN_DLLEXPORT virtual void close() override;
 
   DISKANN_DLLEXPORT virtual void register_thread() override;
-  DISKANN_DLLEXPORT virtual void deregister_thread() override {
-      // TODO: Needs implementation.
-  }
+
   DISKANN_DLLEXPORT virtual void deregister_all_threads() override {
       // TODO: Needs implementation.
   }
-  DISKANN_DLLEXPORT virtual IOContext &get_ctx() override;
 
   // process batch of aligned requests in parallel
   // NOTE :: blocking call for the calling thread, but can thread-safe

--- a/thirdparty/DiskANN/src/CMakeLists.txt
+++ b/thirdparty/DiskANN/src/CMakeLists.txt
@@ -8,7 +8,7 @@ if(MSVC)
 	add_subdirectory(dll)
 else()
 	#file(GLOB CPP_SOURCES *.cpp)
-	set(CPP_SOURCES ann_exception.cpp aux_utils.cpp distance.cpp index.cpp
+	set(CPP_SOURCES ann_exception.cpp aio_context_pool.cpp aux_utils.cpp distance.cpp index.cpp
         linux_aligned_file_reader.cpp math_utils.cpp memory_mapper.cpp
         partition_and_pq.cpp  pq_flash_index.cpp logger.cpp utils.cpp)
 	add_library(${PROJECT_NAME} STATIC ${CPP_SOURCES})

--- a/thirdparty/DiskANN/src/aio_context_pool.cpp
+++ b/thirdparty/DiskANN/src/aio_context_pool.cpp
@@ -1,0 +1,66 @@
+#ifndef _WINDOWS
+
+#include "aio_context_pool.h"
+#include <mutex>
+
+namespace {
+  size_t           global_aio_pool_size = 0;
+  size_t           global_aio_max_events = 0;
+  std::mutex       global_aio_pool_mut;
+  const size_t     default_pool_size = std::thread::hardware_concurrency();
+  constexpr size_t default_max_events = 32;
+}  // namespace
+
+AioContextPool::AioContextPool(size_t num_ctx, size_t max_events)
+    : num_ctx_(num_ctx), max_events_(max_events) {
+  for (size_t i = 0; i < num_ctx_; ++i) {
+    io_context_t ctx = 0;
+    int          ret = io_setup(max_events, &ctx);
+
+    if (ret != 0) {
+      assert(-ret != EAGAIN);
+      assert(-ret != ENOMEM);
+      std::cerr << "io_setup() failed; returned " << ret << ", errno=" << -ret
+                << ":" << ::strerror(-ret) << std::endl;
+    } else {
+      LOG(DEBUG) << "allocating ctx: " << ctx;
+      ctx_q_.push(ctx);
+    }
+  }
+}
+
+void AioContextPool::InitGlobalAioPool(size_t num_ctx, size_t max_events) {
+  if (num_ctx <= 0) {
+    LOG(ERROR) << "num_ctx should be bigger than 0";
+    return;
+  }
+  if (global_aio_pool_size == 0) {
+    std::scoped_lock lk(global_aio_pool_mut);
+    if (global_aio_pool_size == 0) {
+      global_aio_pool_size = num_ctx;
+      global_aio_max_events = max_events;
+      return;
+    }
+  }
+  LOG(WARNING)
+      << "Global AioContextPool has already been inialized with context num: "
+      << global_aio_pool_size;
+}
+
+std::shared_ptr<AioContextPool> AioContextPool::GetGlobalAioPool() {
+  if (global_aio_pool_size == 0) {
+    std::scoped_lock lk(global_aio_pool_mut);
+    if (global_aio_pool_size == 0) {
+      global_aio_pool_size = default_pool_size;
+      global_aio_max_events = default_max_events;
+      LOG(WARNING) << "Global AioContextPool has not been inialized yet, init "
+                      "it now with context num: "
+                   << global_aio_pool_size;
+    }
+  }
+  static auto pool = std::shared_ptr<AioContextPool>(
+      new AioContextPool(global_aio_pool_size, global_aio_max_events));
+  return pool;
+}
+
+#endif

--- a/thirdparty/DiskANN/src/windows_aligned_file_reader.cpp
+++ b/thirdparty/DiskANN/src/windows_aligned_file_reader.cpp
@@ -52,22 +52,8 @@ void WindowsAlignedFileReader::register_thread() {
   this->ctx_map.insert(std::make_pair(std::this_thread::get_id(), ctx));
 }
 
-IOContext& WindowsAlignedFileReader::get_ctx() {
-  std::unique_lock<std::mutex> lk(this->ctx_mut);
-  if (ctx_map.find(std::this_thread::get_id()) == ctx_map.end()) {
-    std::stringstream stream;
-    stream << "unable to find IOContext for thread_id : "
-           << std::this_thread::get_id() << "\n";
-    throw diskann::ANNException(stream.str(), -2, __FUNCSIG__, __FILE__,
-                                __LINE__);
-  }
-  IOContext& ctx = ctx_map[std::this_thread::get_id()];
-  lk.unlock();
-  return ctx;
-}
-
 void WindowsAlignedFileReader::read(std::vector<AlignedRead>& read_reqs,
-                                    IOContext& ctx, bool async) {
+                                    bool async) {
   using namespace std::chrono_literals;
   // execute each request sequentially
   _u64 n_reqs = read_reqs.size();


### PR DESCRIPTION
Signed-off-by: zh Wang <zihao.wang@zilliz.com>

issue: #525 

Now in DiskANN, the thread id and aio context id is coupled together, which is unnecessary and error prone. This PR uses a pool to decouple them.