### PR TITLE
Remove redundant slice unittests

### DIFF
--- a/unittest/test_annoy.cpp
+++ b/unittest/test_annoy.cpp
@@ -134,14 +134,3 @@ TEST_P(AnnoyTest, annoy_serialize) {
     auto result = index_->Query(query_dataset, conf_, nullptr);
     AssertAnns(result, nq, knowhere::GetMetaTopk(conf_));
 }
-
-TEST_P(AnnoyTest, annoy_slice) {
-    // serialize index
-    index_->BuildAll(base_dataset, conf_);
-    auto binaryset = index_->Serialize(knowhere::Config());
-    index_->Load(binaryset);
-    ASSERT_EQ(index_->Count(), nb);
-    ASSERT_EQ(index_->Dim(), dim);
-    auto result = index_->Query(query_dataset, conf_, nullptr);
-    AssertAnns(result, nq, knowhere::GetMetaTopk(conf_));
-}

--- a/unittest/test_binaryidmap.cpp
+++ b/unittest/test_binaryidmap.cpp
@@ -140,24 +140,6 @@ TEST_P(BinaryIDMAPTest, binaryidmap_serialize) {
     AssertAnns(result_bs_1, nq, k, CheckMode::CHECK_NOT_EQUAL);
 }
 
-TEST_P(BinaryIDMAPTest, binaryidmap_slice) {
-    // serialize index
-    index_->BuildAll(base_dataset, conf_);
-    auto result1 = index_->Query(query_dataset, conf_, nullptr);
-    AssertAnns(result1, nq, k);
-    // PrintResult(result1, nq, k);
-    EXPECT_EQ(index_->Count(), nb);
-    EXPECT_EQ(index_->Dim(), dim);
-    auto binaryset = index_->Serialize(conf_);
-
-    index_->Load(binaryset);
-    EXPECT_EQ(index_->Count(), nb);
-    EXPECT_EQ(index_->Dim(), dim);
-    auto result2 = index_->Query(query_dataset, conf_, nullptr);
-    AssertAnns(result2, nq, k);
-    // PrintResult(result2, nq, k);
-}
-
 TEST_P(BinaryIDMAPTest, binaryidmap_range_search_hamming) {
     knowhere::MetricType metric_type = knowhere::metric::HAMMING;
     knowhere::SetMetaMetricType(conf_, metric_type);

--- a/unittest/test_binaryivf.cpp
+++ b/unittest/test_binaryivf.cpp
@@ -117,19 +117,6 @@ TEST_P(BinaryIVFTest, binaryivf_serialize) {
     // PrintResult(result, nq, k);
 }
 
-TEST_P(BinaryIVFTest, binaryivf_slice) {
-    // serialize index
-    index_->BuildAll(base_dataset, conf_);
-    auto binaryset = index_->Serialize(conf_);
-
-    index_->Load(binaryset);
-    EXPECT_EQ(index_->Count(), nb);
-    EXPECT_EQ(index_->Dim(), dim);
-    auto result = index_->Query(query_dataset, conf_, nullptr);
-    AssertAnns(result, nq, knowhere::GetMetaTopk(conf_));
-    // PrintResult(result, nq, k);
-}
-
 TEST_P(BinaryIVFTest, binaryivf_range_search_hamming) {
     knowhere::MetricType metric_type = knowhere::metric::HAMMING;
     knowhere::SetMetaMetricType(conf_, knowhere::metric::HAMMING);

--- a/unittest/test_hnsw.cpp
+++ b/unittest/test_hnsw.cpp
@@ -132,17 +132,6 @@ TEST_P(HNSWTest, HNSW_serialize) {
     AssertAnns(result, nq, k);
 }
 
-TEST_P(HNSWTest, hnsw_slice) {
-    // serialize index
-    index_->BuildAll(base_dataset, conf_);
-    auto binaryset = index_->Serialize(knowhere::Config());
-    index_->Load(binaryset);
-    ASSERT_EQ(index_->Count(), nb);
-    ASSERT_EQ(index_->Dim(), dim);
-    auto result = index_->Query(query_dataset, conf_, nullptr);
-    AssertAnns(result, nq, knowhere::GetMetaTopk(conf_));
-}
-
 TEST_P(HNSWTest, hnsw_range_search_l2) {
     knowhere::MetricType metric_type = knowhere::metric::L2;
     knowhere::SetMetaMetricType(conf_, metric_type);

--- a/unittest/test_idmap.cpp
+++ b/unittest/test_idmap.cpp
@@ -167,31 +167,6 @@ TEST_P(IDMAPTest, idmap_serialize) {
     // PrintResult(result, nq, k);
 }
 
-TEST_P(IDMAPTest, idmap_slice) {
-    index_->BuildAll(base_dataset, conf_);
-
-#ifdef KNOWHERE_GPU_VERSION
-    if (index_mode_ == knowhere::IndexMode::MODE_GPU) {
-        // cpu to gpu
-        index_ = std::dynamic_pointer_cast<knowhere::IDMAP>(index_->CopyCpuToGpu(DEVICE_ID, conf_));
-    }
-#endif
-
-    auto re_result = index_->Query(query_dataset, conf_, nullptr);
-    AssertAnns(re_result, nq, k);
-    // PrintResult(re_result, nq, k);
-    EXPECT_EQ(index_->Count(), nb);
-    EXPECT_EQ(index_->Dim(), dim);
-    auto binaryset = index_->Serialize(conf_);
-
-    index_->Load(binaryset);
-    EXPECT_EQ(index_->Count(), nb);
-    EXPECT_EQ(index_->Dim(), dim);
-    auto result = index_->Query(query_dataset, conf_, nullptr);
-    AssertAnns(result, nq, k);
-    // PrintResult(result, nq, k);
-}
-
 TEST_P(IDMAPTest, idmap_range_search_l2) {
     knowhere::MetricType metric_type = knowhere::metric::L2;
     knowhere::SetMetaMetricType(conf_, metric_type);

--- a/unittest/test_ivf.cpp
+++ b/unittest/test_ivf.cpp
@@ -141,18 +141,6 @@ TEST_P(IVFTest, ivf_serialize) {
     AssertAnns(result, nq, knowhere::GetMetaTopk(conf_));
 }
 
-TEST_P(IVFTest, ivf_slice) {
-    // serialize index
-    index_->BuildAll(base_dataset, conf_);
-    auto binaryset = index_->Serialize(conf_);
-
-    index_->Load(binaryset);
-    EXPECT_EQ(index_->Count(), nb);
-    EXPECT_EQ(index_->Dim(), dim);
-    auto result = index_->Query(query_dataset, conf_, nullptr);
-    AssertAnns(result, nq, knowhere::GetMetaTopk(conf_));
-}
-
 TEST_P(IVFTest, ivf_range_search_l2) {
     if (index_mode_ != knowhere::IndexMode::MODE_CPU) {
         return;


### PR DESCRIPTION
The functionality "assemble()" and "disassemble()" has been removed from knowhere,
so related slice unittests can be removed, related PR #502
Signed-off-by: yudong.cai <yudong.cai@zilliz.com>