### PR TITLE
Use elkan's algo to accelerate KMeans

### DIFF
--- a/thirdparty/DiskANN/include/math_utils.h
+++ b/thirdparty/DiskANN/include/math_utils.h
@@ -10,6 +10,9 @@ namespace math_utils {
 
   float calc_distance(float* vec_1, float* vec_2, size_t dim);
 
+  void elkan_L2(const float* x, const float* y, size_t d, size_t nx, size_t ny,
+                uint32_t* ids);
+
   // compute l2-squared norms of data stored in row major num_points * dim,
   // needs
   // to be pre-allocated


### PR DESCRIPTION
Signed-off-by: zh Wang <zihao.wang@zilliz.com>

issue: #538 

This PR replaces blas matrix multiplication with elkan's algo to accelerate kmeans, which gains over 20x speedup of pq training and encoding in sift1m dataset with the same search performance.