### PR TITLE
Remove K range check

### DIFF
--- a/knowhere/index/vector_index/ConfAdapter.cpp
+++ b/knowhere/index/vector_index/ConfAdapter.cpp
@@ -90,9 +90,6 @@ ConfAdapter::CheckTrain(Config& cfg, const IndexMode mode) {
 
 bool
 ConfAdapter::CheckSearch(Config& cfg, const IndexType type, const IndexMode mode) {
-    const int64_t DEFAULT_MIN_K = 1;
-    const int64_t DEFAULT_MAX_K = 16384;
-    CheckIntegerRange(cfg, meta::TOPK, DEFAULT_MIN_K - 1, DEFAULT_MAX_K);
     return true;
 }
 


### PR DESCRIPTION
Signed-off-by: liliu-z <li.liu@zilliz.com>

Milvus need to loose the K limit, so Knowhere has to do so. Actually, only the hard limit, which will crash the process, should be limited in Knowhere. All other suggestive limits should not be checked here but in Milvus.