### PR TITLE
Add Sanity Check after HNSW Build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -246,6 +246,8 @@ if ( BUILD_COVERAGE STREQUAL "ON" )
                            )
 endif ()
 
+append_flags(CMAKE_CXX_FLAGS FLAGS "-fexceptions" "-fnon-call-exceptions")
+
 add_subdirectory( knowhere/utils )
 add_subdirectory( thirdparty )
 add_subdirectory( knowhere )

--- a/knowhere/CMakeLists.txt
+++ b/knowhere/CMakeLists.txt
@@ -90,6 +90,8 @@ if (KNOWHERE_WITH_DISKANN)
              )
 endif()
 
+set(depend_libs ${depend_libs} segvcatch)
+
 if (KNOWHERE_GPU_VERSION)
     include_directories(${CUDA_INCLUDE_DIRS})
     link_directories("${CUDA_TOOLKIT_ROOT_DIR}/lib64")

--- a/knowhere/index/vector_index/helpers/Slice.cpp
+++ b/knowhere/index/vector_index/helpers/Slice.cpp
@@ -15,6 +15,7 @@
 
 #include "index/vector_index/helpers/IndexParameter.h"
 #include "index/vector_index/helpers/Slice.h"
+#include "common/Log.h"
 
 namespace knowhere {
 
@@ -39,17 +40,21 @@ Slice(const std::string& prefix,
     }
 
     int slice_num = 0;
+    int64_t total_len_after_slice = 0; // use int64_t as `ri` below
     for (int64_t i = 0; i < data_src->size; ++slice_num) {
         int64_t ri = std::min(i + slice_len, data_src->size);
         auto size = static_cast<size_t>(ri - i);
         auto slice_i = std::shared_ptr<uint8_t[]>(new uint8_t[size]);
         memcpy(slice_i.get(), data_src->data.get() + i, size);
         binarySet.Append(prefix + "_" + std::to_string(slice_num), slice_i, ri - i);
+        total_len_after_slice += (ri - i);
         i = ri;
     }
     ret[NAME] = prefix;
     ret[SLICE_NUM] = slice_num;
     ret[TOTAL_LEN] = data_src->size;
+    LOG_KNOWHERE_INFO_ << "Slice total_len: " << ret[TOTAL_LEN];
+    LOG_KNOWHERE_INFO_ << "Total length after sliced: " << total_len_after_slice;
 }
 
 void

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -194,6 +194,10 @@ if ( KNOWHERE_WITH_DISKANN AND NOT TARGET diskann_ep )
     link_directories( SYSTEM  "${DISKANN_PREFIX}/${CMAKE_INSTALL_LIBDIR}/" )
 endif()
 
+# ****************************** Thirdparty segvcatch ***************************************
+add_subdirectory(segvcatch)
+# *********************************************************************
+
 install(DIRECTORY "${KNOWHERE_SOURCE_DIR}/thirdparty/annoy/"
         DESTINATION "include/annoy"
         FILES_MATCHING
@@ -218,6 +222,11 @@ install(DIRECTORY "${KNOWHERE_SOURCE_DIR}/thirdparty/easyloggingpp/"
         PATTERN "*.h" 
 )
 
+install(DIRECTORY "${KNOWHERE_SOURCE_DIR}/thirdparty/segvcatch/"
+        DESTINATION "include/segvcatch"
+        FILES_MATCHING 
+        PATTERN "*.h" 
+)
 
 if ( KNOWHERE_WITH_DISKANN AND TARGET diskann)
     install( DIRECTORY "${KNOWHERE_SOURCE_DIR}/thirdparty/DiskANN/"

--- a/thirdparty/segvcatch/CMakeLists.txt
+++ b/thirdparty/segvcatch/CMakeLists.txt
@@ -1,0 +1,18 @@
+project(segvcatch)
+
+cmake_minimum_required(VERSION 2.6)
+
+if(NOT MSVC)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -fexceptions -fnon-call-exceptions")
+endif()
+
+set(TARGET segvcatch)
+
+set(SOURCES
+  segvcatch.cpp 
+  segvcatch.h
+  i386-signal.h
+  x86_64-signal.h
+)
+
+add_library(${TARGET} STATIC ${SOURCES})

--- a/thirdparty/segvcatch/i386-signal.h
+++ b/thirdparty/segvcatch/i386-signal.h
@@ -1,0 +1,167 @@
+// i386-signal.h - Catch runtime signals and turn them into exceptions
+// on an i386 based Linux system.
+
+/* Copyright (C) 1998, 1999, 2001, 2002, 2006, 2007  Free Software Foundation
+
+   This file is part of libgcj.
+
+This software is copyrighted work licensed under the terms of the
+Libgcj License.  Please consult the file "LIBGCJ_LICENSE" for
+details.  */
+
+
+#ifndef JAVA_SIGNAL_H
+#define JAVA_SIGNAL_H 1
+
+#include <signal.h>
+#include <sys/syscall.h>
+
+#define HANDLE_SEGV 1
+#define HANDLE_FPE 1
+
+#define SIGNAL_HANDLER(_name)					\
+static void _Jv_##_name (int, siginfo_t *,			\
+			 void *_p __attribute__ ((__unused__)))
+
+#define HANDLE_DIVIDE_OVERFLOW						\
+do									\
+{									\
+  struct ucontext *_uc = (struct ucontext *)_p;				\
+  gregset_t &_gregs = _uc->uc_mcontext.gregs;				\
+  unsigned char *_eip = (unsigned char *)_gregs[REG_EIP];		\
+									\
+  /* According to the JVM spec, "if the dividend is the negative	\
+   * integer of largest possible magnitude for the type and the		\
+   * divisor is -1, then overflow occurs and the result is equal to	\
+   * the dividend.  Despite the overflow, no exception occurs".		\
+									\
+   * We handle this by inspecting the instruction which generated the	\
+   * signal and advancing ip to point to the following instruction.	\
+   * As the instructions are variable length it is necessary to do a	\
+   * little calculation to figure out where the following instruction	\
+   * actually is.							\
+									\
+  */									\
+									\
+  /* Detect a signed division of Integer.MIN_VALUE.  */			\
+  if (_eip[0] == 0xf7)							\
+    {									\
+      bool _min_value_dividend = false;					\
+      unsigned char _modrm = _eip[1];					\
+									\
+      if (((_modrm >> 3) & 7) == 7) /* Signed divide */			\
+	{								\
+	  _min_value_dividend =						\
+	    _gregs[REG_EAX] == (greg_t)0x80000000UL;			\
+	}								\
+									\
+      if (_min_value_dividend)						\
+	{								\
+	  unsigned char _rm = _modrm & 7;				\
+	  _gregs[REG_EDX] = 0; /* the remainder is zero */		\
+	  switch (_modrm >> 6)						\
+	    {								\
+	    case 0:  /* register indirect */				\
+	      if (_rm == 5)   /* 32-bit displacement */			\
+		_eip += 4;						\
+	      if (_rm == 4)  /* A SIB byte follows the ModR/M byte */	\
+		_eip += 1;						\
+	      break;							\
+	    case 1:  /* register indirect + 8-bit displacement */	\
+	      _eip += 1;						\
+	      if (_rm == 4)  /* A SIB byte follows the ModR/M byte */	\
+		_eip += 1;						\
+	      break;							\
+	    case 2:  /* register indirect + 32-bit displacement */	\
+	      _eip += 4;						\
+	      if (_rm == 4)  /* A SIB byte follows the ModR/M byte */	\
+		_eip += 1;						\
+	      break;							\
+	    case 3:							\
+	      break;							\
+	    }								\
+	  _eip += 2;							\
+	  _gregs[REG_EIP] = (greg_t)_eip;				\
+	  return;							\
+	}								\
+    }									\
+}									\
+while (0)
+
+/* We use kernel_sigaction here because we're calling the kernel
+   directly rather than via glibc.  The sigaction structure that the
+   syscall uses is a different shape from the one in userland and not
+   visible to us in a header file so we define it here.  */
+
+extern "C" 
+{
+  struct kernel_sigaction 
+  {
+    void (*k_sa_sigaction)(int,siginfo_t *,void *);
+    unsigned long k_sa_flags;
+    void (*k_sa_restorer) (void);
+    sigset_t k_sa_mask;
+  };
+}
+
+#define MAKE_THROW_FRAME(_exception)
+
+#define RESTORE(name, syscall) RESTORE2 (name, syscall)
+#define RESTORE2(name, syscall)			\
+asm						\
+  (						\
+   ".text\n"					\
+   ".byte 0  # Yes, this really is necessary\n" \
+   "	.align 16\n"				\
+   "__" #name ":\n"				\
+   "	movl $" #syscall ", %eax\n"		\
+   "	int  $0x80"				\
+   );
+
+/* The return code for realtime-signals.  */
+RESTORE (restore_rt, __NR_rt_sigreturn)
+void restore_rt (void) asm ("__restore_rt")
+  __attribute__ ((visibility ("hidden")));
+
+#define INIT_SEGV						\
+do								\
+  {								\
+    struct kernel_sigaction act;				\
+    act.k_sa_sigaction = _Jv_catch_segv;			\
+    sigemptyset (&act.k_sa_mask);				\
+    act.k_sa_flags = SA_SIGINFO|0x4000000;			\
+    act.k_sa_restorer = restore_rt;				\
+    syscall (SYS_rt_sigaction, SIGSEGV, &act, NULL, _NSIG / 8);	\
+  }								\
+while (0)  
+
+#define INIT_FPE						\
+do								\
+  {								\
+    struct kernel_sigaction act;				\
+    act.k_sa_sigaction = _Jv_catch_fpe;				\
+    sigemptyset (&act.k_sa_mask);				\
+    act.k_sa_flags = SA_SIGINFO|0x4000000;			\
+    act.k_sa_restorer = restore_rt;				\
+    syscall (SYS_rt_sigaction, SIGFPE, &act, NULL, _NSIG / 8);	\
+  }								\
+while (0)  
+
+/* You might wonder why we use syscall(SYS_sigaction) in INIT_FPE
+ * instead of the standard sigaction().  This is necessary because of
+ * the shenanigans above where we increment the PC saved in the
+ * context and then return.  This trick will only work when we are
+ * called _directly_ by the kernel, because linuxthreads wraps signal
+ * handlers and its wrappers do not copy the sigcontext struct back
+ * when returning from a signal handler.  If we return from our divide
+ * handler to a linuxthreads wrapper, we will lose the PC adjustment
+ * we made and return to the faulting instruction again.  Using
+ * syscall(SYS_sigaction) causes our handler to be called directly
+ * by the kernel, bypassing any wrappers.
+
+ * Also, there may not be any unwind info in the linuxthreads
+ * library's signal handlers and so we can't unwind through them
+ * anyway.  */
+
+#endif /* JAVA_SIGNAL_H */
+  

--- a/thirdparty/segvcatch/segvcatch.cpp
+++ b/thirdparty/segvcatch/segvcatch.cpp
@@ -1,0 +1,151 @@
+/***************************************************************************
+ *   Copyright (C) 2009 by VisualData                                      *
+ *                                                                         *
+ *   Redistributed under LGPL license terms.                               *
+ ***************************************************************************/
+
+#include "segvcatch.h"
+
+#include <string>
+#include <stdexcept>
+
+using namespace std;
+
+namespace
+{
+
+segvcatch::handler handler_segv = 0;
+segvcatch::handler handler_fpe = 0;
+
+#if defined __GNUC__ && __linux
+
+#ifdef __i386__
+#include "i386-signal.h"
+#endif /*__i386__*/
+
+#ifdef __x86_64__
+#include "x86_64-signal.h"
+#endif /*__x86_64__*/
+
+#endif /*defined __GNUC__ && __linux*/
+
+void default_segv()
+{
+    throw std::runtime_error("Segmentation fault");
+}
+
+void default_fpe()
+{
+    throw std::runtime_error("Floating-point exception");
+}
+
+void handle_segv()
+{
+    if (handler_segv)
+        handler_segv();
+}
+
+void handle_fpe()
+{
+    if (handler_fpe)
+        handler_fpe();
+}
+
+#if defined (HANDLE_SEGV) || defined(HANDLE_FPE)
+
+#include <execinfo.h>
+
+/* Unblock a signal.  Unless we do this, the signal may only be sent
+   once.  */
+static void unblock_signal(int signum __attribute__((__unused__)))
+{
+#ifdef _POSIX_VERSION
+    sigset_t sigs;
+    sigemptyset(&sigs);
+    sigaddset(&sigs, signum);
+    sigprocmask(SIG_UNBLOCK, &sigs, NULL);
+#endif
+}
+#endif
+
+#ifdef HANDLE_SEGV
+
+SIGNAL_HANDLER(catch_segv)
+{
+    unblock_signal(SIGSEGV);
+    MAKE_THROW_FRAME(nullp);
+    handle_segv();
+}
+#endif
+
+#ifdef HANDLE_FPE
+
+SIGNAL_HANDLER(catch_fpe)
+{
+    unblock_signal(SIGFPE);
+#ifdef HANDLE_DIVIDE_OVERFLOW
+    HANDLE_DIVIDE_OVERFLOW;
+#else
+    MAKE_THROW_FRAME(arithexception);
+#endif
+    handle_fpe();
+}
+#endif
+
+#ifdef WIN32
+#include <windows.h>
+
+static LONG CALLBACK win32_exception_handler(LPEXCEPTION_POINTERS e)
+{
+    if (e->ExceptionRecord->ExceptionCode == EXCEPTION_ACCESS_VIOLATION)
+    {
+        handle_segv();
+        return EXCEPTION_CONTINUE_EXECUTION;
+    }
+    else if (e->ExceptionRecord->ExceptionCode == EXCEPTION_INT_DIVIDE_BY_ZERO)
+    {
+        handle_fpe();
+        return EXCEPTION_CONTINUE_EXECUTION;
+    }
+    else
+        return EXCEPTION_CONTINUE_SEARCH;
+}
+#endif
+}
+
+
+namespace segvcatch
+{
+
+void init_segv(handler h)
+{
+    if (h)
+        handler_segv = h;
+    else
+        handler_segv = default_segv;
+#ifdef HANDLE_SEGV
+    INIT_SEGV;
+#endif
+
+#ifdef WIN32
+    SetUnhandledExceptionFilter(win32_exception_handler);
+#endif
+}
+
+void init_fpe(handler h)
+{
+    if (h)
+        handler_fpe = h;
+    else
+        handler_fpe = default_fpe;
+#ifdef HANDLE_FPE
+    INIT_FPE;
+#endif
+
+#ifdef WIN32
+    SetUnhandledExceptionFilter(win32_exception_handler);
+#endif
+
+}
+
+}

--- a/thirdparty/segvcatch/segvcatch.h
+++ b/thirdparty/segvcatch/segvcatch.h
@@ -1,0 +1,33 @@
+/***************************************************************************
+ *   Copyright (C) 2009 by VisualData                                      *
+ *                                                                         *
+ *   Redistributed under LGPL license terms.                               *
+ ***************************************************************************/
+
+#ifndef _SEGVCATCH_H
+#define	_SEGVCATCH_H
+
+/*! \brief segvcatch namespace
+
+
+*/
+namespace segvcatch
+{
+
+/*! Signal handler, used to redefine standart exception throwing. */
+typedef void (*handler)();
+
+/*! Initialize segmentation violation handler.
+    \param h (optional) - optional user's signal handler. By default used an internal signal handler to throw
+ std::runtime_error.
+   */
+void init_segv(handler h = 0);
+
+/*! Initialize floating point error handler.
+    \param h - optional user's signal handler. By default used an internal signal handler to throw
+ std::runtime_error.*/
+void init_fpe(handler h = 0);
+
+}
+
+#endif	/* _SEGVCATCH_H */

--- a/thirdparty/segvcatch/x86_64-signal.h
+++ b/thirdparty/segvcatch/x86_64-signal.h
@@ -1,0 +1,182 @@
+// x86_64-signal.h - Catch runtime signals and turn them into exceptions
+// on an x86_64 based GNU/Linux system.
+
+/* Copyright (C) 2003, 2006, 2007  Free Software Foundation
+
+   This file is part of libgcj.
+
+This software is copyrighted work licensed under the terms of the
+Libgcj License.  Please consult the file "LIBGCJ_LICENSE" for
+details.  */
+
+
+#ifdef __x86_64__
+
+# ifndef JAVA_SIGNAL_H
+#  define JAVA_SIGNAL_H 1
+
+#  include <signal.h>
+#  include <unistd.h>
+#  include <sys/syscall.h>
+
+#  define HANDLE_SEGV 1
+#  define HANDLE_FPE 1
+
+#  define SIGNAL_HANDLER(_name)					\
+static void _Jv_##_name (int, siginfo_t *,			\
+			 void *_p __attribute__ ((__unused__)))
+
+#  define HANDLE_DIVIDE_OVERFLOW						\
+do									\
+{									\
+  ucontext_t *_uc = (ucontext_t *)_p;					\
+  gregset_t &_gregs = _uc->uc_mcontext.gregs;				\
+  unsigned char *_rip = (unsigned char *)_gregs[REG_RIP];		\
+									\
+  /* According to the JVM spec, "if the dividend is the negative	\
+   * integer of largest possible magnitude for the type and the		\
+   * divisor is -1, then overflow occurs and the result is equal to	\
+   * the dividend.  Despite the overflow, no exception occurs".		\
+									\
+   * We handle this by inspecting the instruction which generated the	\
+   * signal and advancing ip to point to the following instruction.	\
+   * As the instructions are variable length it is necessary to do a	\
+   * little calculation to figure out where the following instruction	\
+   * actually is.							\
+									\
+   */									\
+									\
+  bool _is_64_bit = false;						\
+									\
+  if ((_rip[0] & 0xf0) == 0x40)  /* REX byte present.  */		\
+    {									\
+      unsigned char _rex = _rip[0] & 0x0f;				\
+      _is_64_bit = (_rex & 0x08) != 0;					\
+      _rip++;								\
+    }									\
+									\
+  /* Detect a signed division of Integer.MIN_VALUE or Long.MIN_VALUE.  */ \
+  if (_rip[0] == 0xf7)							\
+    {									\
+      bool _min_value_dividend = false;					\
+      unsigned char _modrm = _rip[1];					\
+									\
+      if (((_modrm >> 3) & 7) == 7)					\
+	{								\
+	  if (_is_64_bit)						\
+	    _min_value_dividend =					\
+	      _gregs[REG_RAX] == (greg_t)0x8000000000000000UL;		\
+	  else								\
+	    _min_value_dividend =					\
+	      (_gregs[REG_RAX] & 0xffffffff) == (greg_t)0x80000000UL;	\
+	}								\
+									\
+      if (_min_value_dividend)						\
+	{								\
+	  unsigned char _rm = _modrm & 7;				\
+	  _gregs[REG_RDX] = 0; /* the remainder is zero */		\
+	  switch (_modrm >> 6)						\
+	    {								\
+	    case 0:  /* register indirect */				\
+	      if (_rm == 5)   /* 32-bit displacement */			\
+		_rip += 4;						\
+	      if (_rm == 4)  /* A SIB byte follows the ModR/M byte */	\
+		_rip += 1;						\
+	      break;							\
+	    case 1:  /* register indirect + 8-bit displacement */	\
+	      _rip += 1;						\
+	      if (_rm == 4)  /* A SIB byte follows the ModR/M byte */	\
+		_rip += 1;						\
+	      break;							\
+	    case 2:  /* register indirect + 32-bit displacement */	\
+	      _rip += 4;						\
+	      if (_rm == 4)  /* A SIB byte follows the ModR/M byte */	\
+		_rip += 1;						\
+	      break;							\
+	    case 3:							\
+	      break;							\
+	    }								\
+	  _rip += 2;							\
+	  _gregs[REG_RIP] = (greg_t)_rip;				\
+	  return;							\
+	}								\
+    }									\
+}									\
+while (0)
+
+extern "C" 
+{
+  struct kernel_sigaction 
+  {
+    void (*k_sa_sigaction)(int,siginfo_t *,void *);
+    unsigned long k_sa_flags;
+    void (*k_sa_restorer) (void);
+    sigset_t k_sa_mask;
+  };
+}
+
+#  define MAKE_THROW_FRAME(_exception)
+
+#  define RESTORE(name, syscall) RESTORE2 (name, syscall)
+#  define RESTORE2(name, syscall)			\
+asm						\
+  (						\
+   ".text\n"					\
+   ".byte 0  # Yes, this really is necessary\n" \
+   ".align 16\n"				\
+   "__" #name ":\n"				\
+   "	movq $" #syscall ", %rax\n"		\
+   "	syscall\n"				\
+   );
+
+/* The return code for realtime-signals.  */
+RESTORE (restore_rt, __NR_rt_sigreturn)
+void restore_rt (void) asm ("__restore_rt")
+  __attribute__ ((visibility ("hidden")));
+
+#  define INIT_SEGV						\
+do								\
+  {								\
+    struct kernel_sigaction act;				\
+    act.k_sa_sigaction = _Jv_catch_segv;			\
+    sigemptyset (&act.k_sa_mask);				\
+    act.k_sa_flags = SA_SIGINFO|0x4000000;			\
+    act.k_sa_restorer = restore_rt;				\
+    syscall (SYS_rt_sigaction, SIGSEGV, &act, NULL, _NSIG / 8);	\
+  }								\
+while (0)  
+
+#  define INIT_FPE						\
+do								\
+  {								\
+    struct kernel_sigaction act;				\
+    act.k_sa_sigaction = _Jv_catch_fpe;				\
+    sigemptyset (&act.k_sa_mask);				\
+    act.k_sa_flags = SA_SIGINFO|0x4000000;			\
+    act.k_sa_restorer = restore_rt;				\
+    syscall (SYS_rt_sigaction, SIGFPE, &act, NULL, _NSIG / 8);	\
+  }								\
+while (0)  
+
+/* You might wonder why we use syscall(SYS_sigaction) in INIT_FPE
+ * instead of the standard sigaction().  This is necessary because of
+ * the shenanigans above where we increment the PC saved in the
+ * context and then return.  This trick will only work when we are
+ * called _directly_ by the kernel, because linuxthreads wraps signal
+ * handlers and its wrappers do not copy the sigcontext struct back
+ * when returning from a signal handler.  If we return from our divide
+ * handler to a linuxthreads wrapper, we will lose the PC adjustment
+ * we made and return to the faulting instruction again.  Using
+ * syscall(SYS_sigaction) causes our handler to be called directly
+ * by the kernel, bypassing any wrappers.  */
+
+# endif /* JAVA_SIGNAL_H */
+
+# else /* __x86_64__ */
+
+/* This is for the 32-bit subsystem on x86-64.  */
+
+# define sigcontext_struct sigcontext
+# include <java-signal-aux.h>
+
+#endif /* __x86_64__ */

--- a/unittest/test_hnsw.cpp
+++ b/unittest/test_hnsw.cpp
@@ -136,7 +136,7 @@ TEST_P(HNSWTest, hnsw_slice) {
     knowhere::SetMetaSliceSize(conf_, knowhere::index_file_slice_size);
     // serialize index
     index_->BuildAll(base_dataset, conf_);
-    auto binaryset = index_->Serialize(knowhere::Config());
+    auto binaryset = index_->Serialize(conf_);
     index_->Load(binaryset);
     ASSERT_EQ(index_->Count(), nb);
     ASSERT_EQ(index_->Dim(), dim);


### PR DESCRIPTION
This PR adds the functionality of performing a dummy search after the build process in HNSW.

This functionality should be used in the cloud environment for debugging purposes ONLY.

Catching Segmentation Faults and continuing to run the program can be tricky as signal and exceptions are two different systems in C++. We want to capture both in this case.

Be aware that this PR introduces compilation flags including `-fexceptions` and `-fnon-call-exceptions` to `knowhere` target. 