### PR TITLE
Use Brute Force when Bitset Filter Rate is High

### DIFF
--- a/include/knowhere/heap.h
+++ b/include/knowhere/heap.h
@@ -1,0 +1,62 @@
+// Copyright (C) 2019-2023 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under the License.
+
+#pragma once
+
+#include <optional>
+#include <queue>
+#include <utility>
+
+namespace knowhere {
+
+// Maintain intermediate top-k results via maxheap
+// TODO: this naive implementation might be optimzed later
+//     1. Based on top-k and pushed element count to swtich strategy
+//     2. Combine `pop` and `push` operation to `replace`
+template <typename DisT, typename IdT>
+class ResultMaxHeap {
+ public:
+    ResultMaxHeap(size_t k) : k_(k){};
+
+    inline std::optional<std::pair<DisT, IdT>>
+    Pop() {
+        if (pq.empty()) {
+            return std::nullopt;
+        }
+        std::optional<std::pair<DisT, IdT>> res = pq.top();
+        pq.pop();
+        return res;
+    }
+
+    inline void
+    Push(DisT dis, IdT id) {
+        if (pq.size() < k_) {
+            pq.emplace(dis, id);
+            return;
+        }
+
+        if (dis < pq.top().first) {
+            pq.pop();
+            pq.emplace(dis, id);
+        }
+    }
+
+    inline size_t
+    Size() {
+        return pq.size();
+    }
+
+ private:
+    size_t k_;
+    std::priority_queue<std::pair<DisT, IdT>> pq;
+};
+
+}  // namespace knowhere

--- a/tests/ut/test_heap.cc
+++ b/tests/ut/test_heap.cc
@@ -1,0 +1,38 @@
+// Copyright (C) 2019-2023 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under the License.
+
+#include <algorithm>
+#include <functional>
+
+#include "catch2/catch_test_macros.hpp"
+#include "knowhere/heap.h"
+#include "utils.h"
+
+namespace {
+constexpr size_t kHeapSize = 10;
+constexpr size_t kElementCount = 10000;
+}  // namespace
+
+TEST_CASE("ResultMaxHeap") {
+    knowhere::ResultMaxHeap<float, size_t> heap(kHeapSize);
+    auto pairs = GenerateRandomDistanceIdPair(kElementCount);
+    for (const auto& [dist, id] : pairs) {
+        heap.Push(dist, id);
+    }
+    REQUIRE(heap.Size() == kHeapSize);
+    std::sort(pairs.begin(), pairs.end());
+    for (int i = kHeapSize - 1; i >= 0; --i) {
+        auto op = heap.Pop();
+        REQUIRE(op.has_value());
+        REQUIRE(op.value().second == pairs[i].second);
+    }
+    REQUIRE(heap.Size() == 0);
+}

--- a/tests/ut/test_utils.cc
+++ b/tests/ut/test_utils.cc
@@ -9,11 +9,17 @@
 // is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 // or implied. See the License for the specific language governing permissions and limitations under the License.
 
+#include <vector>
+
 #include "catch2/catch_approx.hpp"
 #include "catch2/catch_test_macros.hpp"
 #include "knowhere/comp/time_recorder.h"
 #include "knowhere/utils.h"
 #include "utils.h"
+
+namespace {
+const std::vector<size_t> kBitsetSizes{4, 8, 10, 64, 100, 500, 1024};
+}
 
 TEST_CASE("Test Vector Normalization", "[normalize]") {
     using Catch::Approx;
@@ -36,6 +42,37 @@ TEST_CASE("Test Vector Normalization", "[normalize]") {
                 sum += val * val;
             }
             CHECK(std::abs(1.0f - sum) <= floatDiff);
+        }
+    }
+}
+
+TEST_CASE("Test Bitset Generation", "[utils]") {
+    SECTION("Sequential") {
+        for (const auto size : kBitsetSizes) {
+            for (size_t i = 0; i <= size; ++i) {
+                auto bitset_data = GenerateBitsetWithFirstTbitsSet(size, i);
+                knowhere::BitsetView bitset(bitset_data.data(), size);
+                for (size_t j = 0; j < i; ++j) {
+                    REQUIRE(bitset.test(j));
+                }
+                for (size_t j = i; j < size; ++j) {
+                    REQUIRE(!bitset.test(j));
+                }
+            }
+        }
+    }
+
+    SECTION("Random") {
+        for (const auto size : kBitsetSizes) {
+            for (size_t i = 0; i <= size; ++i) {
+                auto bitset_data = GenerateBitsetWithRandomTbitsSet(size, i);
+                knowhere::BitsetView bitset(bitset_data.data(), size);
+                size_t cnt = 0;
+                for (size_t j = 0; j < size; ++j) {
+                    cnt += bitset.test(j);
+                }
+                REQUIRE(cnt == i);
+            }
         }
     }
 }

--- a/tests/ut/utils.h
+++ b/tests/ut/utils.h
@@ -10,6 +10,9 @@
 // or implied. See the License for the specific language governing permissions and limitations under the License.
 
 #include <algorithm>
+#include <cstdint>
+#include <limits>
+#include <memory>
 #include <queue>
 #include <random>
 #include <set>
@@ -19,7 +22,7 @@
 #include "knowhere/binaryset.h"
 #include "knowhere/dataset.h"
 
-namespace {
+constexpr int64_t kSeed = 42;
 using IdDisPair = std::pair<int64_t, float>;
 struct DisPairLess {
     bool
@@ -27,7 +30,6 @@ struct DisPairLess {
         return p1.second < p2.second;
     }
 };
-};  // namespace
 
 inline knowhere::DataSetPtr
 GenDataSet(int rows, int dim, int seed = 42) {
@@ -207,4 +209,53 @@ GetRangeSearchRecall(const knowhere::DataSet& gt, const knowhere::DataSet& resul
     float precision = ninter * 1.0f / res_lims_p[nq];
 
     return (1 + precision) * recall / 2;
+}
+
+// Generate two bitset percentages from given threshold, so that bruteforce
+// strategy can be fully tested
+inline std::vector<float>
+GetBitsetTestPercentagesFromThreshold(const float threshold) {
+    assert(threshold >= 0 && threshold <= 1.0f);
+    return {threshold / 2, threshold + (1 - threshold) / 2};
+}
+
+// Return a n-bits bitset data with first t bits set to true
+inline std::vector<uint8_t>
+GenerateBitsetWithFirstTbitsSet(size_t n, size_t t) {
+    assert(t >= 0 && t <= n);
+    std::vector<uint8_t> data((n + 8 - 1) / 8, 0);
+    for (size_t i = 0; i < t; ++i) {
+        data[i >> 3] |= (0x1 << (i & 0x7));
+    }
+    return data;
+}
+
+// Return a n-bits bitset data with random t bits set to true
+inline std::vector<uint8_t>
+GenerateBitsetWithRandomTbitsSet(size_t n, size_t t) {
+    assert(t >= 0 && t <= n);
+    std::vector<bool> bits_shuffle(n, false);
+    for (size_t i = 0; i < t; ++i) bits_shuffle[i] = true;
+    std::mt19937 g(kSeed);
+    std::shuffle(bits_shuffle.begin(), bits_shuffle.end(), g);
+    std::vector<uint8_t> data((n + 8 - 1) / 8, 0);
+    for (size_t i = 0; i < n; ++i) {
+        if (bits_shuffle[i]) {
+            data[i >> 3] |= (0x1 << (i & 0x7));
+        }
+    }
+    return data;
+}
+
+// Randomly generate n (distances, id) pairs
+inline std::vector<std::pair<float, size_t>>
+GenerateRandomDistanceIdPair(size_t n) {
+    std::mt19937 rng(kSeed);
+    std::uniform_real_distribution<> distrib(std::numeric_limits<float>().min(), std::numeric_limits<float>().max());
+    std::vector<std::pair<float, size_t>> res;
+    res.reserve(n);
+    for (size_t i = 0; i < n; ++i) {
+        res.emplace_back(distrib(rng), i);
+    }
+    return res;
 }

--- a/thirdparty/DiskANN/include/diskann/defines_export.h
+++ b/thirdparty/DiskANN/include/diskann/defines_export.h
@@ -1,0 +1,5 @@
+#pragma once
+
+namespace diskann {
+  constexpr float kDiskAnnBruteForceFilterRate = 0.9f;
+} // namespace diskann

--- a/thirdparty/DiskANN/include/diskann/pq_flash_index.h
+++ b/thirdparty/DiskANN/include/diskann/pq_flash_index.h
@@ -4,6 +4,7 @@
 #pragma once
 #include <cassert>
 #include <future>
+#include <optional>
 #include <sstream>
 #include <stack>
 #include <string>
@@ -156,6 +157,19 @@ namespace diskann {
     }
 
     inline void copy_vec_base_data(T *des, const int64_t des_idx, void *src);
+
+    // Init thread data and returns query norm if avaialble.
+    // If there is no value, there is nothing to do with the given query
+    std::optional<float> init_thread_data(ThreadData<T> &data, const T *query1);
+
+    // Brute force search for the given query.
+    // The beam width is adjusted in the function.
+    void brute_force_beam_search(
+        ThreadData<T> &data, const float query_norm, const _u64 k_search,
+        _s64 *indices, float *distances, const _u64 beam_width_param, IOContext &ctx,
+        QueryStats                                      *stats,
+        const knowhere::feder::diskann::FederResultUniq &feder,
+        knowhere::BitsetView                             bitset_view);
 
     // index info
     // nhood of node `i` is in sector: [i / nnodes_per_sector]

--- a/thirdparty/DiskANN/include/diskann/utils.h
+++ b/thirdparty/DiskANN/include/diskann/utils.h
@@ -39,7 +39,6 @@ typedef int FileHandle;
 #if defined(__ARM_NEON__) && defined(__aarch64__)
 #include "distance_neon.h"
 #endif
-#include "utils.h"
 #include "logger.h"
 #include "cached_io.h"
 #include "ann_exception.h"

--- a/thirdparty/DiskANN/src/pq_flash_index.cpp
+++ b/thirdparty/DiskANN/src/pq_flash_index.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
+#include "diskann/aligned_file_reader.h"
 #include "diskann/logger.h"
 #include "diskann/pq_flash_index.h"
 #include <malloc.h>
@@ -11,6 +12,7 @@
 #include <chrono>
 #include <cmath>
 #include <iterator>
+#include <optional>
 #include <random>
 #include <thread>
 #include <unordered_map>
@@ -19,6 +21,8 @@
 #include "diskann/parameters.h"
 #include "diskann/timer.h"
 #include "diskann/utils.h"
+#include "diskann/defines_export.h"
+#include "knowhere/heap.h"
 
 #include "knowhere/log.h"
 #include "tsl/robin_set.h"
@@ -86,6 +90,7 @@ namespace {
       }
     }
   }
+  constexpr _u64 kBruteForceBeamWidthFactor = 1; // TODO: after experiment, change this value
 }  // namespace
 
 namespace diskann {
@@ -812,29 +817,12 @@ namespace diskann {
 #endif
 
   template<typename T>
-  void PQFlashIndex<T>::cached_beam_search(
-      const T *query1, const _u64 k_search, const _u64 l_search, _s64 *indices,
-      float *distances, const _u64 beam_width, const bool use_reorder_data,
-      QueryStats *stats, const knowhere::feder::diskann::FederResultUniq &feder,
-      knowhere::BitsetView bitset_view) {
-    ThreadData<T> data = this->thread_data.pop();
-    while (data.scratch.sector_scratch == nullptr) {
-      this->thread_data.wait_for_push_notify();
-      data = this->thread_data.pop();
-    }
-    auto ctx = this->reader->get_ctx();
-
-    if (beam_width > MAX_N_SECTOR_READS)
-      throw ANNException("Beamwidth can not be higher than MAX_N_SECTOR_READS",
-                         -1, __FUNCSIG__, __FILE__, __LINE__);
-
+  std::optional<float> PQFlashIndex<T>::init_thread_data(ThreadData<T> &data,
+                                                         const T *query1) {
     // copy query to thread specific aligned and allocated memory (for distance
     // calculations we need aligned data)
-    float        query_norm = 0;
-    const T     *query = data.scratch.aligned_query_T;
-    const float *query_float = data.scratch.aligned_query_float;
-
-    auto q_dim = this->data_dim;
+    float query_norm = 0;
+    auto  q_dim = this->data_dim;
     if (metric == diskann::Metric::INNER_PRODUCT) {
       // query_dim need to be specially treated when using IP
       q_dim--;
@@ -849,10 +837,7 @@ namespace diskann {
     // to 0 (this is the extra coordindate used to convert MIPS to L2 search)
     if (metric == diskann::Metric::INNER_PRODUCT) {
       if (query_norm == 0) {
-        // return an empty answer when calcu a zero point
-        this->thread_data.push(data);
-        this->thread_data.push_notify_all();
-        return;
+        return std::nullopt;
       }
       query_norm = std::sqrt(query_norm);
       data.scratch.aligned_query_T[this->data_dim - 1] = 0;
@@ -863,10 +848,171 @@ namespace diskann {
       }
     }
 
-    auto query_scratch = &(data.scratch);
+    data.scratch.reset();
+    return query_norm;
+  }
 
-    // reset query
-    query_scratch->reset();
+  template<typename T>
+  void PQFlashIndex<T>::brute_force_beam_search(
+      ThreadData<T> &data, const float query_norm, const _u64 k_search,
+      _s64 *indices, float *distances, const _u64 beam_width_parm, IOContext &ctx,
+      QueryStats *stats, const knowhere::feder::diskann::FederResultUniq &feder,
+      knowhere::BitsetView bitset_view) {
+    auto     query_scratch = &(data.scratch);
+    const T *query = data.scratch.aligned_query_T;
+    auto beam_width = beam_width_parm * kBruteForceBeamWidthFactor;
+
+    T *data_buf = query_scratch->coord_scratch;
+    std::unordered_map<_u64, std::vector<_u64>> nodes_in_sectors_to_visit;
+    std::vector<AlignedRead>                    frontier_read_reqs;
+    frontier_read_reqs.reserve(2 * beam_width);
+    char *sector_scratch = query_scratch->sector_scratch;
+    _u64 &sector_scratch_idx = query_scratch->sector_idx;
+
+    Timer                                io_timer, query_timer;
+    knowhere::ResultMaxHeap<float, _u64> max_heap(k_search);
+    // TODO: maybe we can pipeline here
+    assert(bitset_view.size() == num_points);
+    for (_u64 id = 0; id < num_points;) {
+      // gathering information about reading which nodes and which sector
+      if (!bitset_view.test(id)) {
+        const _u64 sector_offset = get_node_sector_offset(id);
+        if (nodes_in_sectors_to_visit.find(sector_offset) ==
+            nodes_in_sectors_to_visit.end()) {
+          while (id < num_points &&
+                 get_node_sector_offset(id) == sector_offset) {
+            if (!bitset_view.test(id)) {
+              if (coord_cache.find(id) != coord_cache.end()) {
+                float dist =
+                    dist_cmp(query, coord_cache.at(id), (size_t) aligned_dim);
+                max_heap.Push(dist, id);
+              } else {
+                nodes_in_sectors_to_visit[sector_offset].push_back(id);
+              }
+            }
+            ++id;
+          }
+        } else {
+          LOG_KNOWHERE_ERROR_ << "Should not be visited twice";
+        }
+      } else {
+        ++id;
+      }
+      if (id < num_points && nodes_in_sectors_to_visit.size() < beam_width)
+        continue;
+
+      // perform I/O
+      for (const auto &[sector_offset, ids_in_sectors] :
+           nodes_in_sectors_to_visit) {
+        frontier_read_reqs.emplace_back(
+            sector_offset, read_len_for_node,
+            sector_scratch + sector_scratch_idx * read_len_for_node);
+        ++sector_scratch_idx;
+        if (stats != nullptr) {
+          stats->n_4k++;
+          stats->n_ios++;
+        }
+      }
+      io_timer.reset();
+#ifdef USE_BING_INFRA
+      reader->read(frontier_read_reqs, ctx, true);  // async reader windows.
+#else
+      reader->read(frontier_read_reqs, ctx);    // synchronous IO linux
+#endif
+      if (stats != nullptr) {
+        stats->io_us += (double) io_timer.elapsed();
+      }
+
+      T *node_fp_coords_copy = data_buf;
+      for (const auto &req : frontier_read_reqs) {
+        const _u64 sector_offset = req.offset;
+        char      *sector_buf = reinterpret_cast<char *>(req.buf);
+        for (const auto cur_id : nodes_in_sectors_to_visit[sector_offset]) {
+          char *node_buf = get_offset_to_node(sector_buf, cur_id);
+          memcpy(node_fp_coords_copy, node_buf,
+                 disk_bytes_per_point);  // Do we really need memcpy here?
+          float dist =
+              dist_cmp(query, node_fp_coords_copy, (size_t) aligned_dim);
+          max_heap.Push(dist, cur_id);
+          if (feder != nullptr) {
+            feder->visit_info_.AddTopCandidateInfo(cur_id, dist);
+            feder->id_set_.insert(cur_id);
+          }
+        }
+      }
+
+      nodes_in_sectors_to_visit.clear();
+      frontier_read_reqs.clear();
+      sector_scratch_idx = 0;
+    }
+
+    for (_s64 i = k_search - 1; i >= 0; --i) {
+      if ((_u64) i >= max_heap.Size()) {
+        indices[i] = -1;
+        if (distances != nullptr) {
+          distances[i] = -1;
+        }
+        continue;
+      }
+      if (const auto op = max_heap.Pop()) {
+        const auto [dis, id] = op.value();
+        indices[i] = id;
+        if (distances != nullptr) {
+          distances[i] = dis;
+          if (metric == diskann::Metric::INNER_PRODUCT) {
+            distances[i] = 1.0 - distances[i] / 2.0;
+            if (max_base_norm != 0) {
+              distances[i] *= (max_base_norm * query_norm);
+            }
+          }
+        }
+      } else {
+        LOG_KNOWHERE_ERROR_ << "Size is incorrect";
+      }
+    }
+    if (stats != nullptr) {
+      stats->total_us = (double) query_timer.elapsed();
+    }
+    return;
+  }
+
+  template<typename T>
+  void PQFlashIndex<T>::cached_beam_search(
+      const T *query1, const _u64 k_search, const _u64 l_search, _s64 *indices,
+      float *distances, const _u64 beam_width, const bool use_reorder_data,
+      QueryStats *stats, const knowhere::feder::diskann::FederResultUniq &feder,
+      knowhere::BitsetView bitset_view) {
+    if (beam_width > MAX_N_SECTOR_READS)
+      throw ANNException("Beamwidth can not be higher than MAX_N_SECTOR_READS",
+                         -1, __FUNCSIG__, __FILE__, __LINE__);
+
+    ThreadData<T> data = this->thread_data.pop();
+    while (data.scratch.sector_scratch == nullptr) {
+      this->thread_data.wait_for_push_notify();
+      data = this->thread_data.pop();
+    }
+    auto query_norm_opt = init_thread_data(data, query1);
+    if (!query_norm_opt.has_value()) {
+        // return an empty answer when calcu a zero point
+        this->thread_data.push(data);
+        this->thread_data.push_notify_all();
+        return;
+    }
+    float query_norm = query_norm_opt.value();
+    auto ctx = this->reader->get_ctx();
+
+    if (!bitset_view.empty() && bitset_view.count() > bitset_view.size() * kDiskAnnBruteForceFilterRate) {
+        brute_force_beam_search(data, query_norm, k_search, indices, distances,
+                                beam_width, ctx, stats, feder, bitset_view);
+        this->thread_data.push(data);
+        this->thread_data.push_notify_all();
+        this->reader->put_ctx(ctx);
+        return;
+    }
+
+    auto query_scratch = &(data.scratch);
+    const T     *query = data.scratch.aligned_query_T;
+    const float *query_float = data.scratch.aligned_query_float;
 
     // pointers to buffers for data
     T *data_buf = query_scratch->coord_scratch;
@@ -874,6 +1020,18 @@ namespace diskann {
     // sector scratch
     char *sector_scratch = query_scratch->sector_scratch;
     _u64 &sector_scratch_idx = query_scratch->sector_idx;
+
+    Timer io_timer, query_timer;
+    // cleared every iteration
+    std::vector<unsigned> frontier;
+    frontier.reserve(2 * beam_width);
+    std::vector<std::pair<unsigned, char *>> frontier_nhoods;
+    frontier_nhoods.reserve(2 * beam_width);
+    std::vector<AlignedRead> frontier_read_reqs;
+    frontier_read_reqs.reserve(2 * beam_width);
+    std::vector<std::pair<unsigned, std::pair<unsigned, unsigned *>>>
+        cached_nhoods;
+    cached_nhoods.reserve(2 * beam_width);
 
     // query <-> PQ chunk centers distances
     float *pq_dists = query_scratch->aligned_pqtable_dist_scratch;
@@ -892,7 +1050,7 @@ namespace diskann {
       ::pq_dist_lookup(pq_coord_scratch, n_ids, this->n_chunks, pq_dists,
                        dists_out);
     };
-    Timer                 query_timer, io_timer, cpu_timer;
+    Timer                 cpu_timer;
     std::vector<Neighbor> retset(l_search + 1);
     tsl::robin_set<_u64> &visited = *(query_scratch->visited);
 
@@ -925,17 +1083,6 @@ namespace diskann {
     unsigned hops = 0;
     unsigned num_ios = 0;
     unsigned k = 0;
-
-    // cleared every iteration
-    std::vector<unsigned> frontier;
-    frontier.reserve(2 * beam_width);
-    std::vector<std::pair<unsigned, char *>> frontier_nhoods;
-    frontier_nhoods.reserve(2 * beam_width);
-    std::vector<AlignedRead> frontier_read_reqs;
-    frontier_read_reqs.reserve(2 * beam_width);
-    std::vector<std::pair<unsigned, std::pair<unsigned, unsigned *>>>
-        cached_nhoods;
-    cached_nhoods.reserve(2 * beam_width);
 
     while (k < cur_list_size) {
       auto nk = cur_list_size;

--- a/thirdparty/hnswlib/hnswlib/hnswalg.h
+++ b/thirdparty/hnswlib/hnswlib/hnswalg.h
@@ -23,6 +23,7 @@
 #include "hnswlib.h"
 #include "io/FaissIO.h"
 #include "knowhere/config.h"
+#include "knowhere/heap.h"
 #include "neighbor.h"
 #include "visited_list_pool.h"
 
@@ -34,6 +35,7 @@
 namespace hnswlib {
 typedef unsigned int tableint;
 typedef unsigned int linklistsizeint;
+constexpr float kHnswBruteForceFilterRate = 0.8f;
 
 template <typename dist_t>
 class HierarchicalNSW : public AlgorithmInterface<dist_t> {
@@ -1027,6 +1029,24 @@ class HierarchicalNSW : public AlgorithmInterface<dist_t> {
               const knowhere::feder::hnsw::FederResultUniq& feder_result = nullptr) const {
         if (cur_element_count == 0)
             return {};
+
+        if (!bitset.empty() && bitset.count() > (cur_element_count * kHnswBruteForceFilterRate)) {
+            assert(cur_element_count == bitset.size());
+            knowhere::ResultMaxHeap<dist_t, labeltype> max_heap(k);
+            for (labeltype id = 0; id < cur_element_count; ++id) {
+                if (!bitset.test(id)) {
+                    dist_t dist = fstdistfunc_(query_data, getDataByInternalId(id), dist_func_param_);
+                    max_heap.Push(dist, id);
+                }
+            }
+            const size_t len = std::min(max_heap.Size(), k);
+            std::vector<std::pair<dist_t, labeltype>> result(len);
+            for (int64_t i = len - 1; i >= 0; --i) {
+                const auto op = max_heap.Pop();
+                result[i] = op.value();
+            }
+            return result;
+        }
 
         tableint currObj = enterpoint_node_;
         dist_t curdist = fstdistfunc_(query_data, getDataByInternalId(enterpoint_node_), dist_func_param_);


### PR DESCRIPTION
Issue: #792 

This PR contains:
1. Use brute force strategy when bitset filter rate is high on `HNSW` and `DiskANN`
2. In UT, set `nq` from `1000` to `100` for CPU indices.
3. In UT, test for recall instead of searching for base vectors themselves.