### PR TITLE
Fix DiskANN Access Invalid Address when Query with Bitset

### DIFF
--- a/thirdparty/DiskANN/include/diskann/neighbor.h
+++ b/thirdparty/DiskANN/include/diskann/neighbor.h
@@ -112,13 +112,14 @@ namespace diskann {
   static inline unsigned InsertIntoPool(Neighbor *addr, int K,
                                         Neighbor nn) {
     // find the location to insert
+    assert(K >= 0);
     int left = 0, right = K - 1;
     if (addr[left].distance > nn.distance) {
       memmove((char *) &addr[left + 1], &addr[left], K * sizeof(Neighbor));
       addr[left] = nn;
       return left;
     }
-    if (addr[right].distance < nn.distance) {
+    if (K == 0 || addr[right].distance < nn.distance) {
       addr[K] = nn;
       return K;
     }


### PR DESCRIPTION
issue: #797 

When bitset is set, when `cur_list_size` is `1` and the bitset of the only item in the `retset` is set, it got `memmove`d and `cur_list_size` set to `0`. Then when try to insert to the `retset` later, accessing `right = cur_list_size - 1` will be invalid.

Related test cases will be introduced in the PR #794 