### PR TITLE
Support GetVectorByIds for DiskANN

### DIFF
--- a/tests/ut/test_get_vector.cc
+++ b/tests/ut/test_get_vector.cc
@@ -107,8 +107,12 @@ TEST_CASE("Test Get Vector By Ids", "[GetVectorByIds]") {
         REQUIRE(results.has_value());
         auto xb = (uint8_t*)train_ds->GetTensor();
         auto data = (uint8_t*)results.value()->GetTensor();
-        for (int i = 0; i < nb * dim / 8; ++i) {
-            CHECK(data[i] == xb[i]);
+        const auto data_bytes = dim / 8;
+        for (size_t i = 0; i < nb; ++i) {
+            auto id = ids_ds->GetIds()[i];
+            for (size_t j = 0; j < data_bytes; ++j) {
+                REQUIRE(data[i * data_bytes + j] == xb[id * data_bytes + j]);
+            }
         }
     }
 
@@ -136,8 +140,11 @@ TEST_CASE("Test Get Vector By Ids", "[GetVectorByIds]") {
         REQUIRE(results.has_value());
         auto xb = (float*)train_ds->GetTensor();
         auto data = (float*)results.value()->GetTensor();
-        for (int i = 0; i < nb * dim; ++i) {
-            CHECK(data[i] == xb[i]);
+        for (size_t i = 0; i < nb; ++i) {
+            const auto id = ids_ds->GetIds()[i];
+            for (size_t j = 0; j < dim; ++j) {
+                REQUIRE(data[i * dim + j] == xb[id * dim + j]);
+            }
         }
     }
 }

--- a/tests/ut/utils.h
+++ b/tests/ut/utils.h
@@ -59,12 +59,14 @@ GenBinDataSet(int rows, int dim, int seed = 42) {
 }
 
 inline std::unique_ptr<knowhere::DataSet>
-GenIdsDataSet(int rows, int dim) {
+GenIdsDataSet(int rows, int dim, int64_t seed = 42) {
+    std::mt19937 g(seed);
     auto ds = std::make_unique<knowhere::DataSet>();
     ds->SetRows(rows);
     ds->SetDim(dim);
     int64_t* ids = new int64_t[rows];
     for (int i = 0; i < rows; ++i) ids[i] = i;
+    std::shuffle(ids, ids + rows, g);
     ds->SetIds(ids);
     return ds;
 }

--- a/thirdparty/DiskANN/include/diskann/pq_flash_index.h
+++ b/thirdparty/DiskANN/include/diskann/pq_flash_index.h
@@ -107,6 +107,18 @@ namespace diskann {
         const float l_k_ratio, knowhere::BitsetView bitset_view = nullptr,
         QueryStats *stats = nullptr);
 
+    // assign the index of ids to its corresponding sector and if it is in
+    // cache, write to the output_data
+    DISKANN_DLLEXPORT std::unordered_map<_u64, std::vector<_u64>>
+    get_sectors_layout_and_write_data_from_cache(const int64_t *ids, int64_t n,
+                                                 T *output_data);
+
+    // perform I/O and write to the output_data
+    DISKANN_DLLEXPORT void get_vector_by_sector(const _u64 sector_offset,
+                                                const std::vector<_u64> &ids_idx,
+                                                const int64_t *ids,
+                                                T *output_data);
+
     std::shared_ptr<AlignedFileReader> reader;
 
     DISKANN_DLLEXPORT _u64 get_num_points() const noexcept;


### PR DESCRIPTION
issue: #801

This PR contains:
1. Support GetVectorByIds for DiskANN by
a. Deduplicate ids based on sectors on the disk and write to output if it is in cache
b. Fire up I/O requests per sector and copy data via the thread pool
1. Generate random test ids and change related test cases.