### PR TITLE
Support GetVectorByIds for DiskANN IP Metric

### DIFF
--- a/tests/ut/test_diskann.cc
+++ b/tests/ut/test_diskann.cc
@@ -245,18 +245,20 @@ TEST_CASE("Test DiskANNIndexNode.", "[diskann]") {
         }
         // test get vector by ids
         {
-            if (metric_str == knowhere::metric::L2) {  // run once
-                auto diskann = knowhere::IndexFactory::Instance().Create("DISKANN", diskann_index_pack);
-                auto knn_search_json = knn_search_gen().dump();
-                knowhere::Json knn_json = knowhere::Json::parse(knn_search_json);
-                auto ids_ds = GenIdsDataSet(kNumRows, kDim);
-                auto results = diskann.GetVectorByIds(*ids_ds, knn_json);
-                REQUIRE(results.has_value());
-                auto xb = (float*)base_ds->GetTensor();
-                auto data = (float*)results.value()->GetTensor();
-                for (size_t i = 0; i < kNumRows; ++i) {
-                    auto id = ids_ds->GetIds()[i];
-                    for (size_t j = 0; j < kDim; ++j) {
+            auto diskann = knowhere::IndexFactory::Instance().Create("DISKANN", diskann_index_pack);
+            auto knn_search_json = knn_search_gen().dump();
+            knowhere::Json knn_json = knowhere::Json::parse(knn_search_json);
+            auto ids_ds = GenIdsDataSet(kNumRows, kDim);
+            auto results = diskann.GetVectorByIds(*ids_ds, knn_json);
+            REQUIRE(results.has_value());
+            auto xb = (float*)base_ds->GetTensor();
+            auto data = (float*)results.value()->GetTensor();
+            for (size_t i = 0; i < kNumRows; ++i) {
+                auto id = ids_ds->GetIds()[i];
+                for (size_t j = 0; j < kDim; ++j) {
+                    if (metric_str == knowhere::metric::IP) {
+                        REQUIRE(Catch::Approx(data[i * kDim + j]) == xb[id * kDim + j]);
+                    } else {
                         REQUIRE(data[i * kDim + j] == xb[id * kDim + j]);
                     }
                 }

--- a/tests/ut/test_get_vector.cc
+++ b/tests/ut/test_get_vector.cc
@@ -20,8 +20,8 @@
 TEST_CASE("Test Get Vector By Ids", "[GetVectorByIds]") {
     using Catch::Approx;
 
-    int64_t nb = 10000;
-    int64_t dim = 128;
+    uint64_t nb = 10000;
+    uint64_t dim = 128;
     int64_t seed = 42;
 
     auto base_gen = [&]() {

--- a/thirdparty/DiskANN/include/diskann/pq_flash_index.h
+++ b/thirdparty/DiskANN/include/diskann/pq_flash_index.h
@@ -107,13 +107,16 @@ namespace diskann {
         const float l_k_ratio, knowhere::BitsetView bitset_view = nullptr,
         QueryStats *stats = nullptr);
 
-    // assign the index of ids to its corresponding sector and if it is in
+    // Assign the index of ids to its corresponding sector and if it is in
     // cache, write to the output_data
     DISKANN_DLLEXPORT std::unordered_map<_u64, std::vector<_u64>>
     get_sectors_layout_and_write_data_from_cache(const int64_t *ids, int64_t n,
                                                  T *output_data);
 
-    // perform I/O and write to the output_data
+    // Perform I/O and write to the output_data
+    // Note that when metric type is IP, the vector is reconstructed and is
+    // approximate since the base vector base has been modified in the
+    // build stage
     DISKANN_DLLEXPORT void get_vector_by_sector(const _u64 sector_offset,
                                                 const std::vector<_u64> &ids_idx,
                                                 const int64_t *ids,
@@ -151,6 +154,8 @@ namespace diskann {
                  ? sector_buf
                  : sector_buf + (node_id % nnodes_per_sector) * max_node_len;
     }
+
+    inline void copy_vec_base_data(T *des, const int64_t des_idx, void *src);
 
     // index info
     // nhood of node `i` is in sector: [i / nnodes_per_sector]


### PR DESCRIPTION
issue: #801 

Since the base vector base has been modified in the build stage when the metric type is IP, we can only reconstruct it by reducing one dimension and times `max_base_norm`.