### PR TITLE
add ivf_flat_cc index

### DIFF
--- a/include/knowhere/comp/index_param.h
+++ b/include/knowhere/comp/index_param.h
@@ -26,6 +26,7 @@ constexpr const char* INDEX_FAISS_BIN_IVFFLAT = "BIN_IVF_FLAT";
 
 constexpr const char* INDEX_FAISS_IDMAP = "FLAT";
 constexpr const char* INDEX_FAISS_IVFFLAT = "IVF_FLAT";
+constexpr const char* INDEX_FAISS_IVFFLAT_CC = "IVF_FLAT_CC";
 constexpr const char* INDEX_FAISS_IVFPQ = "IVF_PQ";
 constexpr const char* INDEX_FAISS_IVFSQ8 = "IVF_SQ8";
 
@@ -43,6 +44,7 @@ constexpr const char* INDEX_DISKANN = "DISKANN";
 }  // namespace IndexEnum
 
 namespace meta {
+constexpr const char* INDEX_TYPE = "index_type";
 constexpr const char* METRIC_TYPE = "metric_type";
 constexpr const char* DIM = "dim";
 constexpr const char* TENSOR = "tensor";
@@ -56,6 +58,7 @@ constexpr const char* RANGE_FILTER = "range_filter";
 constexpr const char* INPUT_IDS = "input_ids";
 constexpr const char* OUTPUT_TENSOR = "output_tensor";
 constexpr const char* DEVICE_ID = "gpu_id";
+constexpr const char* NUM_BUILD_THREAD = "num_build_thread";
 constexpr const char* TRACE_VISIT = "trace_visit";
 constexpr const char* JSON_INFO = "json_info";
 constexpr const char* JSON_ID_SET = "json_id_set";
@@ -67,6 +70,7 @@ constexpr const char* NPROBE = "nprobe";
 constexpr const char* NLIST = "nlist";
 constexpr const char* NBITS = "nbits";  // PQ/SQ
 constexpr const char* M = "m";          // PQ param for IVFPQ
+constexpr const char* SSIZE = "ssize";
 // HNSW Params
 constexpr const char* EFCONSTRUCTION = "efConstruction";
 constexpr const char* HNSW_M = "M";

--- a/include/knowhere/comp/thread_pool.h
+++ b/include/knowhere/comp/thread_pool.h
@@ -96,7 +96,7 @@ class ThreadPool {
         int omp_before;
 
      public:
-        explicit ScopedOmpSetter(int num_threads = 1) : omp_before(omp_get_num_threads()) {
+        explicit ScopedOmpSetter(int num_threads = 1) : omp_before(omp_get_max_threads()) {
             omp_set_num_threads(num_threads);
         }
         ~ScopedOmpSetter() {

--- a/include/knowhere/config.h
+++ b/include/knowhere/config.h
@@ -12,10 +12,13 @@
 #ifndef CONFIG_H
 #define CONFIG_H
 
+#include <omp.h>
+
 #include <iostream>
 #include <list>
 #include <optional>
 #include <sstream>
+#include <thread>
 #include <unordered_map>
 #include <unordered_set>
 #include <variant>
@@ -392,6 +395,7 @@ class BaseConfig : public Config {
  public:
     CFG_STRING metric_type;
     CFG_INT k;
+    CFG_INT num_build_thread;
     CFG_FLOAT radius;
     CFG_FLOAT range_filter;
     CFG_BOOL trace_visit;
@@ -401,6 +405,10 @@ class BaseConfig : public Config {
             .set_default(10)
             .description("search for top k similar vector.")
             .set_range(1, std::numeric_limits<CFG_INT>::max())
+            .for_search();
+        KNOWHERE_CONFIG_DECLARE_FIELD(num_build_thread)
+            .set_default(-1)
+            .description("index thread limit for build.")
             .for_search();
         KNOWHERE_CONFIG_DECLARE_FIELD(radius)
             .set_default(0.0)
@@ -415,6 +423,14 @@ class BaseConfig : public Config {
             .description("trace visit for feder")
             .for_search()
             .for_range_search();
+    }
+
+    int
+    get_build_thread_num() const {
+        if (num_build_thread > 0) {
+            return num_build_thread;
+        }
+        return omp_get_max_threads();
     }
 };
 

--- a/src/index/ivf/ivf.cc
+++ b/src/index/ivf/ivf.cc
@@ -43,7 +43,8 @@ template <typename T>
 class IvfIndexNode : public IndexNode {
  public:
     IvfIndexNode(const Object& object) : index_(nullptr) {
-        static_assert(std::is_same<T, faiss::IndexIVFFlat>::value || std::is_same<T, faiss::IndexIVFPQ>::value ||
+        static_assert(std::is_same<T, faiss::IndexIVFFlat>::value || std::is_same<T, faiss::IndexIVFFlatCC>::value ||
+                          std::is_same<T, faiss::IndexIVFPQ>::value ||
                           std::is_same<T, faiss::IndexIVFScalarQuantizer>::value ||
                           std::is_same<T, faiss::IndexBinaryIVF>::value,
                       "not support");
@@ -65,6 +66,9 @@ class IvfIndexNode : public IndexNode {
     HasRawData(const std::string& metric_type) const override {
         if constexpr (std::is_same<faiss::IndexIVFFlat, T>::value) {
             return true;
+        }
+        if constexpr (std::is_same<faiss::IndexIVFFlatCC, T>::value) {
+            return false;
         }
         if constexpr (std::is_same<faiss::IndexIVFPQ, T>::value) {
             return false;
@@ -91,6 +95,9 @@ class IvfIndexNode : public IndexNode {
         if constexpr (std::is_same<faiss::IndexIVFFlat, T>::value) {
             return std::make_unique<IvfFlatConfig>();
         }
+        if constexpr (std::is_same<faiss::IndexIVFFlatCC, T>::value) {
+            return std::make_unique<IvfFlatCcConfig>();
+        }
         if constexpr (std::is_same<faiss::IndexIVFPQ, T>::value) {
             return std::make_unique<IvfPqConfig>();
         }
@@ -114,6 +121,12 @@ class IvfIndexNode : public IndexNode {
             return 0;
         }
         if constexpr (std::is_same<T, faiss::IndexIVFFlat>::value) {
+            auto nb = index_->invlists->compute_ntotal();
+            auto nlist = index_->nlist;
+            auto code_size = index_->code_size;
+            return (nb * code_size + nb * sizeof(int64_t) + nlist * code_size);
+        }
+        if constexpr (std::is_same<T, faiss::IndexIVFFlatCC>::value) {
             auto nb = index_->invlists->compute_ntotal();
             auto nlist = index_->nlist;
             auto code_size = index_->code_size;
@@ -156,6 +169,9 @@ class IvfIndexNode : public IndexNode {
         if constexpr (std::is_same<T, faiss::IndexIVFFlat>::value) {
             return knowhere::IndexEnum::INDEX_FAISS_IVFFLAT;
         }
+        if constexpr (std::is_same<T, faiss::IndexIVFFlatCC>::value) {
+            return knowhere::IndexEnum::INDEX_FAISS_IVFFLAT_CC;
+        }
         if constexpr (std::is_same<T, faiss::IndexIVFPQ>::value) {
             return knowhere::IndexEnum::INDEX_FAISS_IVFPQ;
         }
@@ -179,6 +195,9 @@ namespace knowhere {
 template <typename T>
 Status
 IvfIndexNode<T>::Build(const DataSet& dataset, const Config& cfg) {
+    const BaseConfig& base_cfg = static_cast<const IvfConfig&>(cfg);
+    auto build_thread_num = base_cfg.get_build_thread_num();
+    ThreadPool::ScopedOmpSetter setter(build_thread_num);
     auto err = Train(dataset, cfg);
     if (err != Status::success) {
         return err;
@@ -223,6 +242,8 @@ template <typename T>
 Status
 IvfIndexNode<T>::Train(const DataSet& dataset, const Config& cfg) {
     const BaseConfig& base_cfg = static_cast<const IvfConfig&>(cfg);
+    auto build_thread_num = base_cfg.get_build_thread_num();
+    ThreadPool::ScopedOmpSetter setter(build_thread_num);
 
     // do normalize for COSINE metric type
     if (IsMetricType(base_cfg.metric_type, knowhere::metric::COSINE)) {
@@ -245,6 +266,14 @@ IvfIndexNode<T>::Train(const DataSet& dataset, const Config& cfg) {
             auto nlist = MatchNlist(rows, ivf_flat_cfg.nlist);
             qzr = new (std::nothrow) typename QuantizerT<T>::type(dim, metric.value());
             index = std::make_unique<faiss::IndexIVFFlat>(qzr, dim, nlist, metric.value());
+            index->own_fields = true;
+            index->train(rows, (const float*)data);
+        }
+        if constexpr (std::is_same<faiss::IndexIVFFlatCC, T>::value) {
+            const IvfFlatCcConfig& ivf_flat_cc_cfg = static_cast<const IvfFlatCcConfig&>(cfg);
+            auto nlist = MatchNlist(rows, ivf_flat_cc_cfg.nlist);
+            qzr = new (std::nothrow) typename QuantizerT<T>::type(dim, metric.value());
+            index = std::make_unique<faiss::IndexIVFFlatCC>(qzr, dim, nlist, ivf_flat_cc_cfg.ssize, metric.value());
             index->own_fields = true;
             index->train(rows, (const float*)data);
         }
@@ -288,12 +317,15 @@ IvfIndexNode<T>::Train(const DataSet& dataset, const Config& cfg) {
 
 template <typename T>
 Status
-IvfIndexNode<T>::Add(const DataSet& dataset, const Config&) {
+IvfIndexNode<T>::Add(const DataSet& dataset, const Config& cfg) {
     if (!this->index_) {
         return Status::empty_index;
     }
     auto data = dataset.GetTensor();
     auto rows = dataset.GetRows();
+    const BaseConfig& base_cfg = static_cast<const IvfConfig&>(cfg);
+    auto build_thread_num = base_cfg.get_build_thread_num();
+    ThreadPool::ScopedOmpSetter setter(build_thread_num);
     try {
         if constexpr (std::is_same<T, faiss::IndexIVFFlat>::value) {
             index_->add_without_codes(rows, (const float*)data);
@@ -537,6 +569,22 @@ IvfIndexNode<T>::GetVectorByIds(const DataSet& dataset, const Config& cfg) const
             LOG_KNOWHERE_WARNING_ << "faiss inner error: " << e.what();
             return unexpected(Status::faiss_inner_error);
         }
+    } else if constexpr (std::is_same<T, faiss::IndexIVFFlatCC>::value) {
+        float* data = nullptr;
+        try {
+            data = new float[dim * rows];
+            index_->make_direct_map(true);
+            for (int64_t i = 0; i < rows; i++) {
+                int64_t id = ids[i];
+                assert(id >= 0 && id < index_->ntotal);
+                index_->reconstruct(id, data + i * dim);
+            }
+            return GenResultDataSet(rows, dim, data);
+        } catch (const std::exception& e) {
+            std::unique_ptr<float> auto_del(data);
+            LOG_KNOWHERE_WARNING_ << "faiss inner error: " << e.what();
+            return unexpected(Status::faiss_inner_error);
+        }
     } else {
         return unexpected(Status::not_implemented);
     }
@@ -701,6 +749,12 @@ KNOWHERE_REGISTER_GLOBAL(IVFFLAT,
                          [](const Object& object) { return Index<IvfIndexNode<faiss::IndexIVFFlat>>::Create(object); });
 KNOWHERE_REGISTER_GLOBAL(IVF_FLAT,
                          [](const Object& object) { return Index<IvfIndexNode<faiss::IndexIVFFlat>>::Create(object); });
+KNOWHERE_REGISTER_GLOBAL(IVFFLATCC, [](const Object& object) {
+    return Index<IvfIndexNode<faiss::IndexIVFFlatCC>>::Create(object);
+});
+KNOWHERE_REGISTER_GLOBAL(IVF_FLAT_CC, [](const Object& object) {
+    return Index<IvfIndexNode<faiss::IndexIVFFlatCC>>::Create(object);
+});
 KNOWHERE_REGISTER_GLOBAL(IVFPQ,
                          [](const Object& object) { return Index<IvfIndexNode<faiss::IndexIVFPQ>>::Create(object); });
 KNOWHERE_REGISTER_GLOBAL(IVF_PQ,

--- a/src/index/ivf/ivf_config.h
+++ b/src/index/ivf/ivf_config.h
@@ -36,6 +36,18 @@ class IvfConfig : public BaseConfig {
 
 class IvfFlatConfig : public IvfConfig {};
 
+class IvfFlatCcConfig : public IvfFlatConfig {
+ public:
+    int ssize;
+    KNOHWERE_DECLARE_CONFIG(IvfFlatCcConfig) {
+        KNOWHERE_CONFIG_DECLARE_FIELD(ssize)
+            .description("segment size")
+            .set_default(48)
+            .for_train()
+            .set_range(32, 2048);
+    }
+};
+
 class IvfPqConfig : public IvfConfig {
  public:
     int m;

--- a/tests/python/test_index_random.py
+++ b/tests/python/test_index_random.py
@@ -22,6 +22,17 @@ test_data = [
         },
     ),
     (
+        "IVFFLATCC",
+        {
+            "dim": 256,
+            "k": 15,
+            "metric_type": "L2",
+            "n_list": 1024,
+            "nprobe": 1024,
+            "ssize" : 48
+        },
+    ),
+    (
         "IVFSQ",
         {
             "dim": 256,

--- a/tests/python/test_index_with_random.py
+++ b/tests/python/test_index_with_random.py
@@ -21,6 +21,17 @@ test_data = [
             "nprobe": 1024,
         },
     ),
+    (
+        "IVFFLATCC",
+        {
+            "dim": 256,
+            "k": 15,
+            "metric_type": "L2",
+            "nlist": 1024,
+            "nprobe": 1024,
+            "ssize": 48
+        },
+    ),
     # (
     #     "IVFSQ",
     #     {

--- a/tests/python/test_index_with_sift.py
+++ b/tests/python/test_index_with_sift.py
@@ -48,6 +48,17 @@ test_data = [
         },
     ),
     (
+        "IVFFLATCC",
+        {
+            "dim": 128,
+            "k": 100,
+            "metric_type": "L2",
+            "n_list": 1024,
+            "nprobe": 128,
+            "ssize": 48
+        },
+    ),
+    (
         "IVFSQ",
         {
             "dim": 128,

--- a/tests/ut/test_get_vector.cc
+++ b/tests/ut/test_get_vector.cc
@@ -55,6 +55,12 @@ TEST_CASE("Test Get Vector By Ids", "[GetVectorByIds]") {
         return json;
     };
 
+    auto ivfflatcc_gen = [&ivfflat_gen]() {
+        knowhere::Json json = ivfflat_gen();
+        json[knowhere::indexparam::SSIZE] = 48;
+        return json;
+    };
+
     auto bin_ivfflat_gen = [&base_bin_gen]() {
         knowhere::Json json = base_bin_gen();
         json[knowhere::indexparam::NLIST] = 16;
@@ -118,6 +124,7 @@ TEST_CASE("Test Get Vector By Ids", "[GetVectorByIds]") {
         auto [name, gen] = GENERATE_REF(table<std::string, std::function<knowhere::Json()>>({
             make_tuple(knowhere::IndexEnum::INDEX_FAISS_IDMAP, flat_gen),
             make_tuple(knowhere::IndexEnum::INDEX_FAISS_IVFFLAT, ivfflat_gen),
+            make_tuple(knowhere::IndexEnum::INDEX_FAISS_IVFFLAT_CC, ivfflatcc_gen),
             make_tuple(knowhere::IndexEnum::INDEX_HNSW, hnsw_gen),
         }));
         auto idx = knowhere::IndexFactory::Instance().Create(name);

--- a/tests/ut/test_ivfflat_cc.cc
+++ b/tests/ut/test_ivfflat_cc.cc
@@ -1,0 +1,281 @@
+// Copyright (C) 2019-2023 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under the License.
+
+#include <future>
+
+#include "catch2/catch_approx.hpp"
+#include "catch2/catch_test_macros.hpp"
+#include "catch2/generators/catch_generators.hpp"
+#include "faiss/invlists/InvertedLists.h"
+#include "knowhere/comp/index_param.h"
+#include "knowhere/factory.h"
+#include "utils.h"
+
+TEST_CASE("Test Build Search Concurrency", "[Concurrency]") {
+    using Catch::Approx;
+
+    int64_t nb = 10000, nq = 1000;
+    int64_t dim = 128;
+    int64_t seed = 42;
+    int64_t times = 5;
+    int64_t top_k = 100;
+    int64_t build_task_num = 1;
+    int64_t search_task_num = 10;
+
+    auto base_gen = [&]() {
+        knowhere::Json json;
+        json[knowhere::meta::DIM] = dim;
+        json[knowhere::meta::METRIC_TYPE] = knowhere::metric::L2;
+        json[knowhere::meta::TOPK] = top_k;
+        json[knowhere::meta::RADIUS] = 10.0;
+        json[knowhere::meta::RANGE_FILTER] = 0.0;
+        return json;
+    };
+
+    auto ivfflat_gen = [&base_gen]() {
+        knowhere::Json json = base_gen();
+        json[knowhere::indexparam::NLIST] = 128;
+        json[knowhere::indexparam::NPROBE] = 16;
+        return json;
+    };
+
+    auto ivfflatcc_gen = [&ivfflat_gen]() {
+        knowhere::Json json = ivfflat_gen();
+        json[knowhere::meta::NUM_BUILD_THREAD] = 1;
+        json[knowhere::indexparam::SSIZE] = 48;
+        return json;
+    };
+
+    SECTION("Test Concurrent Invlists ") {
+        size_t nlist = 128;
+        size_t code_size = 512;
+        size_t segment_size = 1024;
+
+        auto invList = std::make_unique<faiss::ConcurrentArrayInvertedLists>(nlist, code_size, segment_size);
+
+        for (size_t i = 0; i < nlist; i++) {
+            REQUIRE(invList->list_size(i) == 0);
+        }
+
+        std::vector<size_t> list_size_count(nlist, 0);
+        for (int cnt = 0; cnt < times; cnt++) {
+            {
+                // small batch append
+                std::uniform_int_distribution<int> distribution(0, segment_size);
+                for (size_t i = 0; i < nlist; i++) {
+                    std::mt19937_64 rng(i);
+                    int64_t add_size = distribution(rng);
+                    std::vector<faiss::Index::idx_t> ids(add_size, i);
+                    std::vector<uint8_t> codes(add_size * code_size, (uint8_t)(i % 256));
+                    invList->add_entries(i, add_size, ids.data(), codes.data());
+                    list_size_count[i] += add_size;
+                    CHECK(invList->list_size(i) == list_size_count[i]);
+                }
+            }
+            {
+                // large batch append
+                std::uniform_int_distribution<int> distribution(1, 5 * segment_size);
+                for (size_t i = 0; i < nlist; i++) {
+                    std::mt19937_64 rng(i * i);
+                    int64_t add_size = distribution(rng);
+                    std::vector<faiss::Index::idx_t> ids(add_size, i);
+                    std::vector<uint8_t> codes(add_size * code_size, (uint8_t)(i % 256));
+                    invList->add_entries(i, add_size, ids.data(), codes.data());
+                    list_size_count[i] += add_size;
+                    CHECK(invList->list_size(i) == list_size_count[i]);
+                }
+            }
+        }
+        {
+            for (size_t i = 0; i < nlist; i++) {
+                auto list_size = list_size_count[i];
+                CHECK(invList->get_segment_num(i) == ((list_size / segment_size) + (list_size % segment_size != 0)));
+                CHECK(invList->get_segment_size(i, invList->get_segment_num(i) - 1) ==
+                      (list_size % segment_size == 0 ? segment_size : list_size % segment_size));
+                CHECK(invList->get_segment_offset(i, 0) == 0);
+
+                for (size_t j = 0; j < list_size; j++) {
+                    CHECK(*(invList->get_ids(i, j)) == static_cast<int64_t>(i));
+                }
+
+                for (size_t j = 0; j < list_size; j++) {
+                    for (size_t k = 0; k < code_size; k++) {
+                        CHECK(*(invList->get_codes(i, j) + k) == static_cast<int64_t>(i));
+                    }
+                }
+            }
+        }
+    }
+
+    SECTION("Test Add & Search & RangeSearch Serialized ") {
+        using std::make_tuple;
+        auto [name, gen] = GENERATE_REF(table<std::string, std::function<knowhere::Json()>>({
+            make_tuple(knowhere::IndexEnum::INDEX_FAISS_IVFFLAT_CC, ivfflatcc_gen),
+        }));
+        auto idx = knowhere::IndexFactory::Instance().Create(name);
+        auto cfg_json = gen().dump();
+        CAPTURE(name, cfg_json);
+        knowhere::Json json = knowhere::Json::parse(cfg_json);
+        auto train_ds = GenDataSet(nb, dim, seed);
+        auto res = idx.Build(*train_ds, json);
+        REQUIRE(res == knowhere::Status::success);
+        REQUIRE(idx.Type() == name);
+
+        auto& build_ds = train_ds;
+        auto query_ds = GenDataSet(nq, dim, seed);
+
+        for (int i = 1; i <= times; i++) {
+            idx.Add(*build_ds, json);
+            {
+                auto results = idx.Search(*query_ds, json, nullptr);
+                REQUIRE(results.has_value());
+                auto ids = results.value()->GetIds();
+                for (int j = 0; j < nq; ++j) {
+                    // duplicate result
+                    for (int k = 0; k <= i; k++) {
+                        CHECK(ids[j * top_k + k] % nb == j);
+                    }
+                }
+            }
+            {
+                auto results = idx.RangeSearch(*query_ds, json, nullptr);
+                REQUIRE(results.has_value());
+                auto ids = results.value()->GetIds();
+                auto lims = results.value()->GetLims();
+                for (int j = 0; j < nq; ++j) {
+                    for (int k = 0; k <= i; k++) {
+                        CHECK(ids[lims[j] + k] % nb == j);
+                    }
+                }
+            }
+        }
+    }
+
+    SECTION("Test Build & Search Correctness") {
+        using std::make_tuple;
+
+        auto ivf_flat = knowhere::IndexFactory::Instance().Create(knowhere::IndexEnum::INDEX_FAISS_IVFFLAT);
+        auto ivf_flat_cc = knowhere::IndexFactory::Instance().Create(knowhere::IndexEnum::INDEX_FAISS_IVFFLAT_CC);
+
+        knowhere::Json ivf_flat_json = knowhere::Json::parse(ivfflat_gen().dump());
+        knowhere::Json ivf_flat_cc_json = knowhere::Json::parse(ivfflatcc_gen().dump());
+
+        auto train_ds = GenDataSet(nb, dim, seed);
+        auto query_ds = GenDataSet(nq, dim, seed);
+
+        auto flat_res = ivf_flat.Build(*train_ds, ivf_flat_json);
+        REQUIRE(flat_res == knowhere::Status::success);
+        auto cc_res = ivf_flat_cc.Build(*train_ds, ivf_flat_json);
+        REQUIRE(cc_res == knowhere::Status::success);
+
+        // test search
+        {
+            auto flat_results = ivf_flat.Search(*query_ds, ivf_flat_json, nullptr);
+            REQUIRE(flat_results.has_value());
+
+            auto cc_results = ivf_flat_cc.Search(*query_ds, ivf_flat_json, nullptr);
+            REQUIRE(cc_results.has_value());
+
+            auto flat_ids = flat_results.value()->GetIds();
+            auto cc_ids = cc_results.value()->GetIds();
+            for (int i = 0; i < nq; i++) {
+                for (int j = 0; j < top_k; j++) {
+                    auto id = i * top_k + j;
+                    CHECK(flat_ids[id] == cc_ids[id]);
+                }
+            }
+        }
+        // test range_search
+        {
+            auto flat_results = ivf_flat.RangeSearch(*query_ds, ivf_flat_json, nullptr);
+            REQUIRE(flat_results.has_value());
+
+            auto cc_results = ivf_flat_cc.RangeSearch(*query_ds, ivf_flat_json, nullptr);
+            REQUIRE(cc_results.has_value());
+
+            auto flat_ids = flat_results.value()->GetIds();
+            auto flat_limits = flat_results.value()->GetLims();
+            auto cc_ids = cc_results.value()->GetIds();
+            auto cc_limits = cc_results.value()->GetLims();
+            for (int i = 0; i < nq; i++) {
+                CHECK(flat_limits[i] == cc_limits[i]);
+                CHECK(flat_limits[i + 1] == cc_limits[i + 1]);
+                for (size_t offset = flat_limits[i]; offset < flat_limits[i + 1]; offset++) {
+                    CHECK(flat_ids[offset] == cc_ids[offset]);
+                }
+            }
+        }
+    }
+
+    SECTION("Test Add & Search & RangeSearch ConCurrent") {
+        using std::make_tuple;
+        auto [name, gen] = GENERATE_REF(table<std::string, std::function<knowhere::Json()>>({
+            make_tuple(knowhere::IndexEnum::INDEX_FAISS_IVFFLAT_CC, ivfflatcc_gen),
+        }));
+        auto idx = knowhere::IndexFactory::Instance().Create(name);
+        auto cfg_json = gen().dump();
+        CAPTURE(name, cfg_json);
+        knowhere::Json json = knowhere::Json::parse(cfg_json);
+        auto train_ds = GenDataSet(nb, dim, seed);
+        auto res = idx.Build(*train_ds, json);
+        REQUIRE(res == knowhere::Status::success);
+        REQUIRE(idx.Type() == name);
+
+        auto& build_ds = train_ds;
+        auto query_ds = GenDataSet(nq, dim, seed);
+
+        for (int i = 1; i <= times; i++) {
+            std::vector<std::future<knowhere::Status>> add_task_list;
+            std::vector<std::future<knowhere::expected<knowhere::DataSetPtr, knowhere::Status>>> search_task_list;
+            std::vector<std::future<knowhere::expected<knowhere::DataSetPtr, knowhere::Status>>> range_search_task_list;
+            for (int j = 0; j < build_task_num; j++) {
+                add_task_list.push_back(
+                    std::async(std::launch::async, [&idx, &build_ds, &json] { return idx.Add(*build_ds, json); }));
+            }
+            for (int j = 0; j < search_task_num; j++) {
+                search_task_list.push_back(std::async(
+                    std::launch::async, [&idx, &query_ds, &json] { return idx.Search(*query_ds, json, nullptr); }));
+            }
+            for (int j = 0; j < search_task_num; j++) {
+                range_search_task_list.push_back(std::async(std::launch::async, [&idx, &query_ds, &json] {
+                    return idx.RangeSearch(*query_ds, json, nullptr);
+                }));
+            }
+            for (auto& task : add_task_list) {
+                REQUIRE(task.get() == knowhere::Status::success);
+            }
+
+            for (auto& task : search_task_list) {
+                auto results = task.get();
+                REQUIRE(results.has_value());
+                auto ids = results.value()->GetIds();
+                for (int j = 0; j < nq; ++j) {
+                    // duplicate result
+                    for (int k = 0; k < i; k++) {
+                        CHECK(ids[j * top_k + k] % nb == j);
+                    }
+                }
+            }
+            for (auto& task : range_search_task_list) {
+                auto results = task.get();
+                REQUIRE(results.has_value());
+                auto ids = results.value()->GetIds();
+                auto lims = results.value()->GetLims();
+                for (int j = 0; j < nq; ++j) {
+                    // duplicate result
+                    for (int k = 0; k < i; k++) {
+                        CHECK(ids[lims[j] + k] % nb == j);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/ut/test_search.cc
+++ b/tests/ut/test_search.cc
@@ -51,6 +51,12 @@ TEST_CASE("Test All Mem Index Search", "[search]") {
         return json;
     };
 
+    auto ivfflatcc_gen = [&ivfflat_gen]() {
+        knowhere::Json json = ivfflat_gen();
+        json[knowhere::indexparam::SSIZE] = 48;
+        return json;
+    };
+
     auto ivfsq_gen = ivfflat_gen;
 
     auto flat_gen = base_gen;
@@ -94,6 +100,7 @@ TEST_CASE("Test All Mem Index Search", "[search]") {
         auto [name, gen] = GENERATE_REF(table<std::string, std::function<knowhere::Json()>>({
             make_tuple(knowhere::IndexEnum::INDEX_FAISS_IDMAP, flat_gen),
             make_tuple(knowhere::IndexEnum::INDEX_FAISS_IVFFLAT, ivfflat_gen),
+            make_tuple(knowhere::IndexEnum::INDEX_FAISS_IVFFLAT_CC, ivfflatcc_gen),
             make_tuple(knowhere::IndexEnum::INDEX_FAISS_IVFSQ8, ivfsq_gen),
             make_tuple(knowhere::IndexEnum::INDEX_FAISS_IVFPQ, ivfpq_gen),
             make_tuple(knowhere::IndexEnum::INDEX_HNSW, hnsw_gen),
@@ -119,6 +126,7 @@ TEST_CASE("Test All Mem Index Search", "[search]") {
         auto [name, gen] = GENERATE_REF(table<std::string, std::function<knowhere::Json()>>({
             make_tuple(knowhere::IndexEnum::INDEX_FAISS_IDMAP, flat_gen),
             make_tuple(knowhere::IndexEnum::INDEX_FAISS_IVFFLAT, ivfflat_gen),
+            make_tuple(knowhere::IndexEnum::INDEX_FAISS_IVFFLAT_CC, ivfflatcc_gen),
             make_tuple(knowhere::IndexEnum::INDEX_FAISS_IVFSQ8, ivfsq_gen),
             // make_tuple(knowhere::IndexEnum::INDEX_FAISS_IVFPQ, ivfpq_gen),
             make_tuple(knowhere::IndexEnum::INDEX_HNSW, hnsw_gen),
@@ -180,6 +188,7 @@ TEST_CASE("Test All Mem Index Search", "[search]") {
         auto [name, gen] = GENERATE_REF(table<std::string, std::function<knowhere::Json()>>({
             make_tuple(knowhere::IndexEnum::INDEX_FAISS_IDMAP, flat_gen),
             make_tuple(knowhere::IndexEnum::INDEX_FAISS_IVFFLAT, ivfflat_gen),
+            make_tuple(knowhere::IndexEnum::INDEX_FAISS_IVFFLAT_CC, ivfflatcc_gen),
             make_tuple(knowhere::IndexEnum::INDEX_FAISS_IVFSQ8, ivfsq_gen),
             make_tuple(knowhere::IndexEnum::INDEX_FAISS_IVFPQ, ivfpq_gen),
             make_tuple(knowhere::IndexEnum::INDEX_HNSW, hnsw_gen),

--- a/thirdparty/faiss/faiss/IndexIVFFlat.cpp
+++ b/thirdparty/faiss/faiss/IndexIVFFlat.cpp
@@ -264,6 +264,29 @@ void IndexIVFFlat::reconstruct_from_offset_without_codes(
 #endif
 }
 
+IndexIVFFlatCC::IndexIVFFlatCC(
+        Index* quantizer,
+        size_t d,
+        size_t nlist,
+        size_t ssize,
+        MetricType metric)
+        : IndexIVFFlat(quantizer, d, nlist, metric) {
+    replace_invlists(new ConcurrentArrayInvertedLists(nlist, code_size, ssize), true);
+}
+
+void IndexIVFFlatCC::add_with_ids_without_codes(
+        idx_t n,
+        const float* x,
+        const idx_t* xids) {
+    FAISS_THROW_MSG("ivfflat_cc index not support add_without_codes operation");
+}
+
+void IndexIVFFlatCC::reconstruct_from_offset_without_codes(
+        int64_t list_no,
+        int64_t offset,
+        float* recons) const {
+    FAISS_THROW_MSG("ivfflat_cc index not support reconstruct_from_offset_without_codes operation");
+}
 /*****************************************
  * IndexIVFFlatDedup implementation
  ******************************************/

--- a/thirdparty/faiss/faiss/IndexIVFFlat.h
+++ b/thirdparty/faiss/faiss/IndexIVFFlat.h
@@ -61,6 +61,27 @@ struct IndexIVFFlat : IndexIVF {
     IndexIVFFlat() {}
 };
 
+struct IndexIVFFlatCC : IndexIVFFlat {
+    IndexIVFFlatCC(
+            Index* quantizer,
+            size_t d,
+            size_t nlist,
+            size_t ssize,
+            MetricType = METRIC_L2);
+
+    /// implemented for all IndexIVF* classes
+    void add_with_ids_without_codes(idx_t n, const float* x, const idx_t* xids)
+            override;
+
+
+    void reconstruct_from_offset_without_codes(
+            int64_t list_no,
+            int64_t offset,
+            float* recons) const override;
+
+    IndexIVFFlatCC() {}
+};
+
 struct IndexIVFFlatDedup : IndexIVFFlat {
     /** Maps ids stored in the index to the ids of vectors that are
      *  the same. When a vector is unique, it does not appear in the


### PR DESCRIPTION
Issue #823 
Add IVF_FLAT_CC to support running build & search on IVF index concurrently by following change
1. Add IVF_FLAT_CC index inherited with IVF_FLAT
2. Replace the InvertedLists implementation from ArrayInvertedLists into ConcurrentArrayInvertedLists