### PR TITLE
Update HNSW Brute Force Threshold While Searching with Bitset

### DIFF
--- a/thirdparty/DiskANN/src/pq_flash_index.cpp
+++ b/thirdparty/DiskANN/src/pq_flash_index.cpp
@@ -1001,7 +1001,7 @@ namespace diskann {
     float query_norm = query_norm_opt.value();
     auto ctx = this->reader->get_ctx();
 
-    if (!bitset_view.empty() && bitset_view.count() > bitset_view.size() * kDiskAnnBruteForceFilterRate) {
+    if (!bitset_view.empty() && bitset_view.count() >= bitset_view.size() * kDiskAnnBruteForceFilterRate) {
         brute_force_beam_search(data, query_norm, k_search, indices, distances,
                                 beam_width, ctx, stats, feder, bitset_view);
         this->thread_data.push(data);

--- a/thirdparty/hnswlib/hnswlib/hnswalg.h
+++ b/thirdparty/hnswlib/hnswlib/hnswalg.h
@@ -35,7 +35,7 @@
 namespace hnswlib {
 typedef unsigned int tableint;
 typedef unsigned int linklistsizeint;
-constexpr float kHnswBruteForceFilterRate = 0.8f;
+constexpr float kHnswBruteForceFilterRate = 0.93f;
 
 template <typename dist_t>
 class HierarchicalNSW : public AlgorithmInterface<dist_t> {
@@ -1030,7 +1030,7 @@ class HierarchicalNSW : public AlgorithmInterface<dist_t> {
         if (cur_element_count == 0)
             return {};
 
-        if (!bitset.empty() && bitset.count() > (cur_element_count * kHnswBruteForceFilterRate)) {
+        if (!bitset.empty() && bitset.count() >= (cur_element_count * kHnswBruteForceFilterRate)) {
             assert(cur_element_count == bitset.size());
             knowhere::ResultMaxHeap<dist_t, labeltype> max_heap(k);
             for (labeltype id = 0; id < cur_element_count; ++id) {


### PR DESCRIPTION
issue: #792 

Based on the experiment results below, when the filter rate is higher than ~93%, brute force outperforms graph search at around ~1M vector scale from GIST and GLOVE datasets.

Thanks @cydrain for running the experiments.

![image](https://user-images.githubusercontent.com/6563846/233537660-49ce779a-9d5f-424c-ae7b-30a538a373c3.png)
![image](https://user-images.githubusercontent.com/6563846/233537723-9ed2e94c-ef43-46a7-ab7f-0f4d2c0450c2.png)

