### PR TITLE
Use PQ and Refine for DiskANN when Bitset Filter Ratio is High

### DIFF
--- a/src/index/diskann/diskann.cc
+++ b/src/index/diskann/diskann.cc
@@ -496,6 +496,7 @@ DiskANNIndexNode<T>::Search(const DataSet& dataset, const Config& cfg, const Bit
     auto k = static_cast<uint64_t>(search_conf.k);
     auto lsearch = static_cast<uint64_t>(search_conf.search_list_size);
     auto beamwidth = static_cast<uint64_t>(search_conf.beamwidth);
+    auto filter_ratio = static_cast<float>(search_conf.filter_threshold);
 
     auto nq = dataset.GetRows();
     auto dim = dataset.GetDim();
@@ -519,7 +520,8 @@ DiskANNIndexNode<T>::Search(const DataSet& dataset, const Config& cfg, const Bit
     for (int64_t row = 0; row < nq; ++row) {
         futures.push_back(pool_->push([&, index = row]() {
             pq_flash_index_->cached_beam_search(xq + (index * dim), k, lsearch, p_id + (index * k),
-                                                p_dist + (index * k), beamwidth, false, nullptr, feder_result, bitset);
+                                                p_dist + (index * k), beamwidth, false, nullptr, feder_result, bitset,
+                                                filter_ratio);
         }));
     }
     for (auto& future : futures) {

--- a/src/index/diskann/diskann_config.h
+++ b/src/index/diskann/diskann_config.h
@@ -69,6 +69,10 @@ class DiskANNConfig : public BaseConfig {
     // DiskANN uses TopK search to simulate range search, this is the ratio of search list size and k. With larger
     // ratio, the accuracy will get higher but throughput will get affected.
     CFG_FLOAT search_list_and_k_ratio;
+    // The threshold which determines when to switch to PQ + Refine strategy based on the number of bits set. The
+    // value should be in range of [0.0, 1.0] which means when greater or equal to x% of the bits are set,
+    // use PQ + Refine. Default to -1.0f, negative vlaues will use dynamic threshold calculator given topk.
+    CFG_FLOAT filter_threshold;
     KNOHWERE_DECLARE_CONFIG(DiskANNConfig) {
         KNOWHERE_CONFIG_DECLARE_FIELD(index_prefix)
             .description("path to load or save Diskann.")
@@ -146,6 +150,11 @@ class DiskANNConfig : public BaseConfig {
             .set_default(2.0)
             .set_range(1.0, 5.0)
             .for_range_search();
+        KNOWHERE_CONFIG_DECLARE_FIELD(filter_threshold)
+            .description("the threshold of filter ratio to use PQ + Refine.")
+            .set_default(-1.0f)
+            .set_range(-1.0f, 1.0f)
+            .for_search();
     }
 };
 }  // namespace knowhere

--- a/tests/ut/test_search.cc
+++ b/tests/ut/test_search.cc
@@ -170,7 +170,7 @@ TEST_CASE("Test All Mem Index Search", "[search]") {
 
         std::vector<std::function<std::vector<uint8_t>(size_t, size_t)>> gen_bitset_funcs = {
             GenerateBitsetWithFirstTbitsSet, GenerateBitsetWithRandomTbitsSet};
-        const auto bitset_percentages = GetBitsetTestPercentagesFromThreshold(threshold);
+        const auto bitset_percentages = {0.4f, 0.98f};
         for (const float percentage : bitset_percentages) {
             for (const auto& gen_func : gen_bitset_funcs) {
                 auto bitset_data = gen_func(nb, percentage * nb);

--- a/tests/ut/utils.h
+++ b/tests/ut/utils.h
@@ -115,14 +115,6 @@ GetRangeSearchRecall(const knowhere::DataSet& gt, const knowhere::DataSet& resul
     return (1 + precision) * recall / 2;
 }
 
-// Generate two bitset percentages from given threshold, so that bruteforce
-// strategy can be fully tested
-inline std::vector<float>
-GetBitsetTestPercentagesFromThreshold(const float threshold) {
-    assert(threshold >= 0 && threshold <= 1.0f);
-    return {threshold / 2, threshold + (1 - threshold) / 2};
-}
-
 // Return a n-bits bitset data with first t bits set to true
 inline std::vector<uint8_t>
 GenerateBitsetWithFirstTbitsSet(size_t n, size_t t) {

--- a/thirdparty/DiskANN/include/diskann/defines_export.h
+++ b/thirdparty/DiskANN/include/diskann/defines_export.h
@@ -1,5 +1,0 @@
-#pragma once
-
-namespace diskann {
-  constexpr float kDiskAnnBruteForceFilterRate = 0.9f;
-} // namespace diskann

--- a/thirdparty/DiskANN/include/diskann/pq_flash_index.h
+++ b/thirdparty/DiskANN/include/diskann/pq_flash_index.h
@@ -100,7 +100,8 @@ namespace diskann {
         float *res_dists, const _u64 beam_width,
         const bool use_reorder_data = false, QueryStats *stats = nullptr,
         const knowhere::feder::diskann::FederResultUniq &feder = nullptr,
-        knowhere::BitsetView                             bitset_view = nullptr);
+        knowhere::BitsetView                             bitset_view = nullptr,
+        const float                                      filter_ratio = -1.0f);
 
     DISKANN_DLLEXPORT _u32 range_search(
         const T *query1, const double range, const _u64 min_l_search,
@@ -163,7 +164,9 @@ namespace diskann {
     // If there is no value, there is nothing to do with the given query
     std::optional<float> init_thread_data(ThreadData<T> &data, const T *query1);
 
-    // Brute force search for the given query.
+    // Brute force search for the given query. Use beam search rather than
+    // sending whole bunch of requests at once to avoid all threads sending I/O
+    // requests and the time overlaps.
     // The beam width is adjusted in the function.
     void brute_force_beam_search(
         ThreadData<T> &data, const float query_norm, const _u64 k_search,


### PR DESCRIPTION
issue: #792 

Calculate PQ distances and refine, instead of brute force strategy when bitset filter ratio is high, to reduce the number of I/Os performed.

The threshold where switching the strategy can be affected by multiple factors, such as topk, dimension, distribution of the dataset and etc. We fit a cautious log function regarding topk and having a safety net setting at 0.5.

This boosts the performance by 80x in the best case.

![gist_final](https://user-images.githubusercontent.com/6563846/236158819-1e9c059d-bad4-42ea-85b0-b64ffd69bf5a.png)


