### PR TITLE
Refactored expected class to remove unexpected and simplify usage

### DIFF
--- a/include/knowhere/comp/brute_force.h
+++ b/include/knowhere/comp/brute_force.h
@@ -19,14 +19,14 @@ namespace knowhere {
 
 class BruteForce {
  public:
-    static expected<DataSetPtr, Status>
+    static expected<DataSetPtr>
     Search(const DataSetPtr base_dataset, const DataSetPtr query_dataset, const Json& config, const BitsetView& bitset);
 
     static Status
     SearchWithBuf(const DataSetPtr base_dataset, const DataSetPtr query_dataset, int64_t* ids, float* dis,
                   const Json& config, const BitsetView& bitset);
 
-    static expected<DataSetPtr, Status>
+    static expected<DataSetPtr>
     RangeSearch(const DataSetPtr base_dataset, const DataSetPtr query_dataset, const Json& config,
                 const BitsetView& bitset);
 };

--- a/include/knowhere/expected.h
+++ b/include/knowhere/expected.h
@@ -41,91 +41,114 @@ enum class Status {
     invalid_binary_set = 19,
 };
 
-template <typename E>
-class unexpected {
- public:
-    constexpr explicit unexpected(const E& err) : err(err) {
-        static_assert(std::is_same<E, Status>::value);
-    }
-
-    constexpr explicit unexpected(E&& err) : err(err) {
-        static_assert(std::is_same<E, Status>::value);
-    }
-
-    ~unexpected() = default;
-
-    E err;
-};
-
-template <typename T, typename E>
+template <typename T>
 class expected {
  public:
     template <typename... Args>
-    expected(Args&&... args) : val(std::forward<Args...>(args...)) {
+    expected(Args&&... args) : val(std::make_optional<T>(std::forward<Args>(args)...)) {
     }
 
-    expected(const unexpected<E>& unexp) {
-        err = unexp.err;
+    expected(const Status& err) : err(err) {
+        assert(err != Status::success);
     }
 
-    expected(unexpected<E>&& unexp) {
-        err = std::move(unexp.err);
+    expected(Status&& err) : err(err) {
+        assert(err != Status::success);
     }
 
-    expected(const expected<T, E>&) = default;
+    expected(const expected<T>&) = default;
 
-    expected(expected<T, E>&&) noexcept = default;
+    expected(expected<T>&&) noexcept = default;
 
     expected&
-    operator=(const expected<T, E>&) = default;
+    operator=(const expected<T>&) = default;
 
     expected&
-    operator=(expected<T, E>&&) noexcept = default;
+    operator=(expected<T>&&) noexcept = default;
 
     bool
-    has_value() {
+    has_value() const {
         return val.has_value();
     }
 
-    E
+    Status
     error() const {
         assert(val.has_value() == false);
         return err.value();
     }
 
-    T&
-    value() {
+    const T&
+    value() const {
         assert(val.has_value() == true);
         return val.value();
     }
 
-    expected<T, E>&
-    operator=(const unexpected<E>& unexp) {
-        err = unexp.err;
+    expected<T>&
+    operator=(const Status& err) {
+        assert(err != Status::success);
+        this->err = err;
         return *this;
     }
 
  private:
     std::optional<T> val = std::nullopt;
-    std::optional<E> err = std::nullopt;
+    std::optional<Status> err = std::nullopt;
 };
 
+// Evaluates expr that returns a Status. Does nothing if the returned Status is
+// a Status::success, otherwise returns the Status from the current function.
+#define RETURN_IF_ERROR(expr)            \
+    do {                                 \
+        auto status = (expr);            \
+        if (status != Status::success) { \
+            return status;               \
+        }                                \
+    } while (0)
+
+template <typename T>
+Status
+DoAssignOrReturn(T& lhs, const expected<T>& exp) {
+    if (exp.has_value()) {
+        lhs = exp.value();
+        return Status::success;
+    }
+    return exp.error();
+}
+
+#define STATUS_INTERNAL_CONCAT_NAME_INNER(x, y) x##y
+#define STATUS_INTERNAL_CONCAT_NAME(x, y) STATUS_INTERNAL_CONCAT_NAME_INNER(x, y)
+
+#define STATUS_INTERNAL_DEPAREN(X) STATUS_INTERNAL_ESC(STATUS_INTERNAL_ISH X)
+#define STATUS_INTERNAL_ISH(...) STATUS_INTERNAL_ISH __VA_ARGS__
+#define STATUS_INTERNAL_ESC(...) STATUS_INTERNAL_ESC_(__VA_ARGS__)
+#define STATUS_INTERNAL_ESC_(...) STATUS_INTERNAL_VAN_STATUS_INTERNAL_##__VA_ARGS__
+#define STATUS_INTERNAL_VAN_STATUS_INTERNAL_STATUS_INTERNAL_ISH
+
+#define STATUS_INTERNAL_ASSIGN_OR_RETURN_IMPL(status, lhs, rexpr) \
+    Status status = knowhere::DoAssignOrReturn(lhs, rexpr);       \
+    if (status != Status::success) {                              \
+        return status;                                            \
+    }
+
+// Evaluates an expression that returns an `expected`. If the expected has a value, assigns
+// the value to var. Otherwise returns the error from the current function.
+//
+// Example: ASSIGN_OR_RETURN(int, i, MaybeInt());
+//
+// If the type parameter has comma not wrapped by paired parenthesis/double quotes, wrap
+// the comma in parenthesis properly.
+//
+// Examples:
+//    ASSIGN_OR_RETURN(std::pair<int, int>, pair, MaybePair());  // Not OK
+//    ASSIGN_OR_RETURN((std::pair<int, int>), pair, MaybePair());  // OK
+//    ASSIGN_OR_RETURN(std::function<void(int, int)>), fn, MaybeFunction());  // OK
+//
+// Note that this macro expands into multiple statements and thus cannot be used in a single statement
+// such as the body of an if statement without {}.
+#define ASSIGN_OR_RETURN(type, var, rexpr) \
+    STATUS_INTERNAL_DEPAREN(type) var;     \
+    STATUS_INTERNAL_ASSIGN_OR_RETURN_IMPL(STATUS_INTERNAL_CONCAT_NAME(_excepted_, __COUNTER__), var, rexpr)
+
 }  // namespace knowhere
-
-#define KNOWHERE_CHECK_STATUS(X)                \
-    do {                                        \
-        auto res = (X);                         \
-        if (res != knowhere::Status::success) { \
-            return res;                         \
-        }                                       \
-    } while (false)
-
-#define KNOWHERE_CHECK_EXPECTED(X)              \
-    do {                                        \
-        auto res = (X);                         \
-        if (res != knowhere::Status::success) { \
-            return knowhere::unexpected(res);   \
-        }                                       \
-    } while (false)
 
 #endif /* EXPECTED_H */

--- a/include/knowhere/index_node.h
+++ b/include/knowhere/index_node.h
@@ -32,19 +32,19 @@ class IndexNode : public Object {
     virtual Status
     Add(const DataSet& dataset, const Config& cfg) = 0;
 
-    virtual expected<DataSetPtr, Status>
+    virtual expected<DataSetPtr>
     Search(const DataSet& dataset, const Config& cfg, const BitsetView& bitset) const = 0;
 
-    virtual expected<DataSetPtr, Status>
+    virtual expected<DataSetPtr>
     RangeSearch(const DataSet& dataset, const Config& cfg, const BitsetView& bitset) const = 0;
 
-    virtual expected<DataSetPtr, Status>
+    virtual expected<DataSetPtr>
     GetVectorByIds(const DataSet& dataset) const = 0;
 
     virtual bool
     HasRawData(const std::string& metric_type) const = 0;
 
-    virtual expected<DataSetPtr, Status>
+    virtual expected<DataSetPtr>
     GetIndexMeta(const Config& cfg) const = 0;
 
     virtual Status

--- a/include/knowhere/index_node_thread_pool_wrapper.h
+++ b/include/knowhere/index_node_thread_pool_wrapper.h
@@ -42,17 +42,17 @@ class IndexNodeThreadPoolWrapper : public IndexNode {
         return index_node_->Add(dataset, cfg);
     }
 
-    expected<DataSetPtr, Status>
+    expected<DataSetPtr>
     Search(const DataSet& dataset, const Config& cfg, const BitsetView& bitset) const {
         return thread_pool_->push([&]() { return this->index_node_->Search(dataset, cfg, bitset); }).get();
     }
 
-    expected<DataSetPtr, Status>
+    expected<DataSetPtr>
     RangeSearch(const DataSet& dataset, const Config& cfg, const BitsetView& bitset) const {
         return thread_pool_->push([&]() { return this->index_node_->RangeSearch(dataset, cfg, bitset); }).get();
     }
 
-    expected<DataSetPtr, Status>
+    expected<DataSetPtr>
     GetVectorByIds(const DataSet& dataset) const {
         return index_node_->GetVectorByIds(dataset);
     }
@@ -62,7 +62,7 @@ class IndexNodeThreadPoolWrapper : public IndexNode {
         return index_node_->HasRawData(metric_type);
     }
 
-    expected<DataSetPtr, Status>
+    expected<DataSetPtr>
     GetIndexMeta(const Config& cfg) const {
         return index_node_->GetIndexMeta(cfg);
     }

--- a/src/common/metric.h
+++ b/src/common/metric.h
@@ -22,7 +22,7 @@
 
 namespace knowhere {
 
-inline expected<faiss::MetricType, Status>
+inline expected<faiss::MetricType>
 Str2FaissMetricType(std::string metric) {
     static const std::unordered_map<std::string, faiss::MetricType> metric_map = {
         {metric::L2, faiss::MetricType::METRIC_L2},
@@ -38,7 +38,7 @@ Str2FaissMetricType(std::string metric) {
     std::transform(metric.begin(), metric.end(), metric.begin(), toupper);
     auto it = metric_map.find(metric);
     if (it == metric_map.end())
-        return unexpected(Status::invalid_metric_type);
+        return Status::invalid_metric_type;
     return it->second;
 }
 

--- a/src/common/raft_metric.h
+++ b/src/common/raft_metric.h
@@ -27,7 +27,7 @@
 
 namespace knowhere {
 
-inline expected<raft::distance::DistanceType, Status>
+inline expected<raft::distance::DistanceType>
 Str2RaftMetricType(std::string metric) {
     static const std::unordered_map<std::string, raft::distance::DistanceType> metric_map = {
         {metric::L2, raft::distance::DistanceType::L2Expanded},
@@ -39,7 +39,7 @@ Str2RaftMetricType(std::string metric) {
     std::transform(metric.begin(), metric.end(), metric.begin(), toupper);
     auto it = metric_map.find(metric);
     if (it == metric_map.end())
-        return unexpected(Status::invalid_metric_type);
+        return Status::invalid_metric_type;
     return it->second;
 }
 

--- a/src/index/cagra/cagra.cu
+++ b/src/index/cagra/cagra.cu
@@ -91,7 +91,7 @@ class CagraIndexNode : public IndexNode {
         return Status::success;
     }
 
-    virtual expected<DataSetPtr, Status>
+    virtual expected<DataSetPtr>
     Search(const DataSet& dataset, const Config& cfg, const BitsetView& bitset) const override {
         auto cagra_cfg = static_cast<const CagraConfig&>(cfg);
         auto rows = dataset.GetRows();
@@ -121,20 +121,20 @@ class CagraIndexNode : public IndexNode {
 
         } catch (std::exception& e) {
             LOG_KNOWHERE_WARNING_ << "RAFT inner error, " << e.what();
-            return unexpected(Status::raft_inner_error);
+            return Status::raft_inner_error;
         }
-        return unexpected(Status::not_implemented);
+        return Status::not_implemented;
         //        return GenResultDataSet(rows, cagra_cfg.k, ids.release(), dis.release());
     }
 
-    expected<DataSetPtr, Status>
+    expected<DataSetPtr>
     RangeSearch(const DataSet& dataset, const Config& cfg, const BitsetView& bitset) const override {
-        return unexpected(Status::not_implemented);
+        return Status::not_implemented;
     }
 
-    virtual expected<DataSetPtr, Status>
+    virtual expected<DataSetPtr>
     GetVectorByIds(const DataSet& dataset) const override {
-        return unexpected(Status::not_implemented);
+        return Status::not_implemented;
     }
 
     virtual bool
@@ -142,9 +142,9 @@ class CagraIndexNode : public IndexNode {
         return false;
     }
 
-    expected<DataSetPtr, Status>
+    expected<DataSetPtr>
     GetIndexMeta(const Config& cfg) const override {
-        return unexpected(Status::not_implemented);
+        return Status::not_implemented;
     }
 
     virtual Status

--- a/src/index/diskann/diskann.cc
+++ b/src/index/diskann/diskann.cc
@@ -55,13 +55,13 @@ class DiskANNIndexNode : public IndexNode {
     Status
     Add(const DataSet& dataset, const Config& cfg) override;
 
-    expected<DataSetPtr, Status>
+    expected<DataSetPtr>
     Search(const DataSet& dataset, const Config& cfg, const BitsetView& bitset) const override;
 
-    expected<DataSetPtr, Status>
+    expected<DataSetPtr>
     RangeSearch(const DataSet& dataset, const Config& cfg, const BitsetView& bitset) const override;
 
-    expected<DataSetPtr, Status>
+    expected<DataSetPtr>
     GetVectorByIds(const DataSet& dataset) const override;
 
     bool
@@ -69,7 +69,7 @@ class DiskANNIndexNode : public IndexNode {
         return IsMetricType(metric_type, metric::L2) || IsMetricType(metric_type, metric::COSINE);
     }
 
-    expected<DataSetPtr, Status>
+    expected<DataSetPtr>
     GetIndexMeta(const Config& cfg) const override;
 
     Status
@@ -170,20 +170,20 @@ namespace {
 static constexpr float kCacheExpansionRate = 1.2;
 static constexpr int kSearchListSizeMaxValue = 200;
 static constexpr int64_t kGetVectorBatchSize = 32;
-template <typename T>
-expected<T, Status>
-TryDiskANNCall(std::function<T()>&& diskann_call) {
+Status
+TryDiskANNCall(std::function<void()>&& diskann_call) {
     try {
-        return diskann_call();
+        diskann_call();
+        return Status::success;
     } catch (const diskann::FileException& e) {
         LOG_KNOWHERE_ERROR_ << "DiskANN File Exception: " << e.what();
-        return unexpected(Status::diskann_file_error);
+        return Status::diskann_file_error;
     } catch (const diskann::ANNException& e) {
         LOG_KNOWHERE_ERROR_ << "DiskANN Exception: " << e.what();
-        return unexpected(Status::diskann_inner_error);
+        return Status::diskann_inner_error;
     } catch (const std::exception& e) {
         LOG_KNOWHERE_ERROR_ << "DiskANN Other Exception: " << e.what();
-        return unexpected(Status::diskann_inner_error);
+        return Status::diskann_inner_error;
     }
 }
 
@@ -298,15 +298,12 @@ DiskANNIndexNode<T>::Add(const DataSet& dataset, const Config& cfg) {
                                                        false,
                                                        build_conf.accelerate_build,
                                                        static_cast<uint32_t>(num_nodes_to_cache)};
-    auto build_stat =
-        TryDiskANNCall<int>([&]() -> int { return diskann::build_disk_index<T>(diskann_internal_build_config); });
-
-    if (!build_stat.has_value()) {
-        return build_stat.error();
-    } else if (build_stat.value() != 0) {
-        LOG_KNOWHERE_ERROR_ << "Diskann inner error.";
-        return Status::diskann_inner_error;
-    }
+    RETURN_IF_ERROR(TryDiskANNCall([&]() {
+        int res = diskann::build_disk_index<T>(diskann_internal_build_config);
+        if (res != 0)
+            throw diskann::ANNException("diskann::build_disk_index returned non-zero value: " + std::to_string(res),
+                                        -1);
+    }));
 
     // Add file to the file manager
     for (auto& filename : GetNecessaryFilenames(index_prefix_, need_norm, true, true)) {
@@ -379,11 +376,13 @@ DiskANNIndexNode<T>::Deserialize(const BinarySet& binset, const Config& cfg) {
     reader.reset(new LinuxAlignedFileReader());
 
     pq_flash_index_ = std::make_unique<diskann::PQFlashIndex<T>>(reader, diskann_metric);
-
-    auto load_expect =
-        TryDiskANNCall<int>([&]() -> int { return pq_flash_index_->load(pool_->size(), index_prefix_.c_str()); });
-
-    if (!load_expect.has_value() || load_expect.value() != 0) {
+    auto disk_ann_call = [&]() {
+        int res = pq_flash_index_->load(pool_->size(), index_prefix_.c_str());
+        if (res != 0) {
+            throw diskann::ANNException("pq_flash_index_->load returned non-zero value: " + std::to_string(res), -1);
+        }
+    };
+    if (TryDiskANNCall(disk_ann_call) != Status::success) {
         LOG_KNOWHERE_ERROR_ << "Failed to load DiskANN.";
         return Status::diskann_inner_error;
     }
@@ -421,25 +420,17 @@ DiskANNIndexNode<T>::Deserialize(const BinarySet& binset, const Config& cfg) {
             LOG_KNOWHERE_INFO_ << "Caching " << num_nodes_to_cache << " sample nodes around medoid(s).";
             if (prep_conf.use_bfs_cache) {
                 LOG_KNOWHERE_INFO_ << "Use bfs to generate cache list";
-                auto gen_cache_expect = TryDiskANNCall<bool>([&]() -> bool {
-                    pq_flash_index_->cache_bfs_levels(num_nodes_to_cache, node_list);
-                    return true;
-                });
-
-                if (!gen_cache_expect.has_value()) {
+                if (TryDiskANNCall([&]() { pq_flash_index_->cache_bfs_levels(num_nodes_to_cache, node_list); }) !=
+                    Status::success) {
                     LOG_KNOWHERE_ERROR_ << "Failed to generate bfs cache for DiskANN.";
                     return Status::diskann_inner_error;
                 }
-
             } else {
                 LOG_KNOWHERE_INFO_ << "Use sample_queries to generate cache list";
-                auto gen_cache_expect = TryDiskANNCall<bool>([&]() -> bool {
-                    pq_flash_index_->generate_cache_list_from_sample_queries(warmup_query_file, 15, 6,
-                                                                             num_nodes_to_cache, node_list);
-                    return true;
-                });
-
-                if (!gen_cache_expect.has_value()) {
+                if (TryDiskANNCall([&]() {
+                        pq_flash_index_->generate_cache_list_from_sample_queries(warmup_query_file, 15, 6,
+                                                                                 num_nodes_to_cache, node_list);
+                    }) != Status::success) {
                     LOG_KNOWHERE_ERROR_ << "Failed to generate cache from sample queries for DiskANN.";
                     return Status::diskann_inner_error;
                 }
@@ -449,12 +440,7 @@ DiskANNIndexNode<T>::Deserialize(const BinarySet& binset, const Config& cfg) {
     }
 
     if (node_list.size() > 0) {
-        auto load_cache_expect = TryDiskANNCall<bool>([&]() -> bool {
-            pq_flash_index_->load_cache_list(node_list);
-            return true;
-        });
-
-        if (!load_cache_expect.has_value()) {
+        if (TryDiskANNCall([&]() { pq_flash_index_->load_cache_list(node_list); }) != Status::success) {
             LOG_KNOWHERE_ERROR_ << "Failed to load cache for DiskANN.";
             return Status::diskann_inner_error;
         }
@@ -468,11 +454,9 @@ DiskANNIndexNode<T>::Deserialize(const BinarySet& binset, const Config& cfg) {
         uint64_t warmup_dim = 0;
         uint64_t warmup_aligned_dim = 0;
         T* warmup = nullptr;
-        auto load_nodes_expect = TryDiskANNCall<bool>([&]() -> bool {
-            diskann::load_aligned_bin<T>(warmup_query_file, warmup, warmup_num, warmup_dim, warmup_aligned_dim);
-            return true;
-        });
-        if (!load_nodes_expect.has_value()) {
+        if (TryDiskANNCall([&]() {
+                diskann::load_aligned_bin<T>(warmup_query_file, warmup, warmup_num, warmup_dim, warmup_aligned_dim);
+            }) != Status::success) {
             LOG_KNOWHERE_ERROR_ << "Failed to load warmup file for DiskANN.";
             return Status::diskann_file_error;
         }
@@ -491,11 +475,7 @@ DiskANNIndexNode<T>::Deserialize(const BinarySet& binset, const Config& cfg) {
             }));
         }
         for (auto& future : futures) {
-            auto one_search_res = TryDiskANNCall<bool>([&]() {
-                future.get();
-                return true;
-            });
-            if (!one_search_res.has_value()) {
+            if (TryDiskANNCall([&]() { future.get(); }) != Status::success) {
                 all_searches_are_good = false;
             }
         }
@@ -514,21 +494,21 @@ DiskANNIndexNode<T>::Deserialize(const BinarySet& binset, const Config& cfg) {
 }
 
 template <typename T>
-expected<DataSetPtr, Status>
+expected<DataSetPtr>
 DiskANNIndexNode<T>::Search(const DataSet& dataset, const Config& cfg, const BitsetView& bitset) const {
     if (!is_prepared_.load() || !pq_flash_index_) {
         LOG_KNOWHERE_ERROR_ << "Failed to load diskann.";
-        return unexpected(Status::empty_index);
+        return Status::empty_index;
     }
 
     auto search_conf = static_cast<const DiskANNConfig&>(cfg);
     if (!CheckMetric(search_conf.metric_type)) {
-        return unexpected(Status::invalid_metric_type);
+        return Status::invalid_metric_type;
     }
     auto max_search_list_size = std::max(kSearchListSizeMaxValue, search_conf.k * 10);
     if (search_conf.search_list_size > max_search_list_size || search_conf.search_list_size < search_conf.k) {
         LOG_KNOWHERE_ERROR_ << "search_list_size should be in range: [topk, max(200, topk * 10)]";
-        return unexpected(Status::invalid_args);
+        return Status::invalid_args;
     }
     auto k = static_cast<uint64_t>(search_conf.k);
     auto lsearch = static_cast<uint64_t>(search_conf.search_list_size);
@@ -543,7 +523,7 @@ DiskANNIndexNode<T>::Search(const DataSet& dataset, const Config& cfg, const Bit
     feder::diskann::FederResultUniq feder_result;
     if (search_conf.trace_visit) {
         if (nq != 1) {
-            return unexpected(Status::invalid_args);
+            return Status::invalid_args;
         }
         feder_result = std::make_unique<feder::diskann::FederResult>();
         feder_result->visit_info_.SetQueryConfig(search_conf.k, search_conf.beamwidth, search_conf.search_list_size);
@@ -563,17 +543,13 @@ DiskANNIndexNode<T>::Search(const DataSet& dataset, const Config& cfg, const Bit
         }));
     }
     for (auto& future : futures) {
-        auto one_search_res = TryDiskANNCall<bool>([&]() {
-            future.get();
-            return true;
-        });
-        if (!one_search_res.has_value()) {
+        if (TryDiskANNCall([&]() { future.get(); }) != Status::success) {
             all_searches_are_good = false;
         }
     }
 
     if (!all_searches_are_good) {
-        return unexpected(Status::diskann_inner_error);
+        return Status::diskann_inner_error;
     }
 
     auto res = GenResultDataSet(nq, k, p_id, p_dist);
@@ -590,20 +566,20 @@ DiskANNIndexNode<T>::Search(const DataSet& dataset, const Config& cfg, const Bit
 }
 
 template <typename T>
-expected<DataSetPtr, Status>
+expected<DataSetPtr>
 DiskANNIndexNode<T>::RangeSearch(const DataSet& dataset, const Config& cfg, const BitsetView& bitset) const {
     if (!is_prepared_.load() || !pq_flash_index_) {
         LOG_KNOWHERE_ERROR_ << "Failed to load diskann.";
-        return unexpected(Status::empty_index);
+        return Status::empty_index;
     }
 
     auto search_conf = static_cast<const DiskANNConfig&>(cfg);
     if (!CheckMetric(search_conf.metric_type)) {
-        return unexpected(Status::invalid_metric_type);
+        return Status::invalid_metric_type;
     }
     if (search_conf.min_k > search_conf.max_k) {
         LOG_KNOWHERE_ERROR_ << "min_k should be smaller than max_k";
-        return unexpected(Status::invalid_args);
+        return Status::invalid_args;
     }
     auto beamwidth = static_cast<uint64_t>(search_conf.beamwidth);
     auto min_k = static_cast<uint64_t>(search_conf.min_k);
@@ -641,16 +617,12 @@ DiskANNIndexNode<T>::RangeSearch(const DataSet& dataset, const Config& cfg, cons
         }));
     }
     for (auto& future : futures) {
-        auto one_search_res = TryDiskANNCall<bool>([&]() {
-            future.get();
-            return true;
-        });
-        if (!one_search_res.has_value()) {
+        if (TryDiskANNCall([&]() { future.get(); }) != Status::success) {
             all_searches_are_good = false;
         }
     }
     if (!all_searches_are_good) {
-        return unexpected(Status::diskann_inner_error);
+        return Status::diskann_inner_error;
     }
 
     GetRangeSearchResult(result_dist_array, result_id_array, is_ip, nq, radius, search_conf.range_filter, p_dist, p_id,
@@ -659,11 +631,11 @@ DiskANNIndexNode<T>::RangeSearch(const DataSet& dataset, const Config& cfg, cons
 }
 
 template <typename T>
-expected<DataSetPtr, Status>
+expected<DataSetPtr>
 DiskANNIndexNode<T>::GetVectorByIds(const DataSet& dataset) const {
     if (!is_prepared_.load() || !pq_flash_index_) {
         LOG_KNOWHERE_ERROR_ << "Failed to load diskann.";
-        return unexpected(Status::empty_index);
+        return Status::empty_index;
     }
 
     auto dim = Dim();
@@ -672,7 +644,7 @@ DiskANNIndexNode<T>::GetVectorByIds(const DataSet& dataset) const {
     float* data = new float[dim * rows];
     if (data == nullptr) {
         LOG_KNOWHERE_ERROR_ << "Failed to allocate memory for data.";
-        return unexpected(Status::malloc_error);
+        return Status::malloc_error;
     }
 
     auto batch_num = (rows + kGetVectorBatchSize - 1) / kGetVectorBatchSize;
@@ -685,23 +657,19 @@ DiskANNIndexNode<T>::GetVectorByIds(const DataSet& dataset) const {
         futures.push_back(pool_->push([=]() { pq_flash_index_->get_vector_by_ids(ids + idx, len, data + idx * dim); }));
     }
     for (auto& future : futures) {
-        auto one_search_res = TryDiskANNCall<bool>([&]() {
-            future.get();
-            return true;
-        });
-        if (!one_search_res.has_value()) {
+        if (TryDiskANNCall([&]() { future.get(); }) != Status::success) {
             all_good = false;
         }
     }
     if (!all_good) {
         delete[] data;
-        return unexpected(Status::diskann_inner_error);
+        return Status::diskann_inner_error;
     }
     return GenResultDataSet(rows, dim, data);
 }
 
 template <typename T>
-expected<DataSetPtr, Status>
+expected<DataSetPtr>
 DiskANNIndexNode<T>::GetIndexMeta(const Config& cfg) const {
     std::vector<int64_t> entry_points;
     for (size_t i = 0; i < pq_flash_index_->get_num_medoids(); i++) {

--- a/src/index/gpu/ivf_gpu/ivf_gpu.cc
+++ b/src/index/gpu/ivf_gpu/ivf_gpu.cc
@@ -56,10 +56,7 @@ class GpuIvfIndexNode : public IndexNode {
 
     virtual Status
     Build(const DataSet& dataset, const Config& cfg) override {
-        auto err = Train(dataset, cfg);
-        if (err != Status::success) {
-            return err;
-        }
+        RETURN_IF_ERROR(Train(dataset, cfg));
         return Add(dataset, cfg);
     }
 
@@ -138,7 +135,7 @@ class GpuIvfIndexNode : public IndexNode {
         return Status::success;
     }
 
-    virtual expected<DataSetPtr, Status>
+    virtual expected<DataSetPtr>
     Search(const DataSet& dataset, const Config& cfg, const BitsetView& bitset) const override {
         auto ivf_gpu_cfg = static_cast<const typename KnowhereConfigType<T>::Type&>(cfg);
 
@@ -161,25 +158,25 @@ class GpuIvfIndexNode : public IndexNode {
             std::unique_ptr<float> auto_delete_dis(dis);
             std::unique_ptr<int64_t> auto_delete_ids(ids);
             LOG_KNOWHERE_WARNING_ << "faiss inner error, " << e.what();
-            return unexpected(Status::faiss_inner_error);
+            return Status::faiss_inner_error;
         }
 
         return GenResultDataSet(rows, ivf_gpu_cfg.k, ids, dis);
     }
 
-    expected<DataSetPtr, Status>
+    expected<DataSetPtr>
     RangeSearch(const DataSet& dataset, const Config& cfg, const BitsetView& bitset) const override {
-        return unexpected(Status::not_implemented);
+        return Status::not_implemented;
     }
 
-    virtual expected<DataSetPtr, Status>
+    virtual expected<DataSetPtr>
     GetVectorByIds(const DataSet& dataset) const override {
-        return unexpected(Status::not_implemented);
+        return Status::not_implemented;
     }
 
-    expected<DataSetPtr, Status>
+    expected<DataSetPtr>
     GetIndexMeta(const Config& cfg) const override {
-        return unexpected(Status::not_implemented);
+        return Status::not_implemented;
     }
 
     virtual Status

--- a/tests/ut/test_ivfflat_cc.cc
+++ b/tests/ut/test_ivfflat_cc.cc
@@ -234,8 +234,8 @@ TEST_CASE("Test Build Search Concurrency", "[Concurrency]") {
 
         for (int i = 1; i <= times; i++) {
             std::vector<std::future<knowhere::Status>> add_task_list;
-            std::vector<std::future<knowhere::expected<knowhere::DataSetPtr, knowhere::Status>>> search_task_list;
-            std::vector<std::future<knowhere::expected<knowhere::DataSetPtr, knowhere::Status>>> range_search_task_list;
+            std::vector<std::future<knowhere::expected<knowhere::DataSetPtr>>> search_task_list;
+            std::vector<std::future<knowhere::expected<knowhere::DataSetPtr>>> range_search_task_list;
             for (int j = 0; j < build_task_num; j++) {
                 add_task_list.push_back(
                     std::async(std::launch::async, [&idx, &build_ds, &json] { return idx.Add(*build_ds, json); }));


### PR DESCRIPTION
1. Make the template parameter of `expected` to be `<T>` instead of `<T, E>`: `expected` is designed to contain either a success value or a fail status, thus no need to make `Status` a template parameter. I don't see `E` to be other classes in current code and I don't aforesee any future other `E` candidates.
2. Remove `unexpected` class and allow `expected` to be constructed directly from `Status`. So we can do just `return Status::some_error:` instead of `return unexpected(Status:some_error);`;
3. Added 2 macros for easier error status handling(avoids tons of boilerplate code):

```cpp
// Functions that return `expected<T>`
// without this pr:
auto res = CallSomeFunc();
if (!res.has_value()) {
  LOG(...);
  return res.error();
}
auto res_value = res.value();

// with this pr:
ASSIGN_OR_RETURN(T, res_value, LOG(...), CallSomeFunc());

// Functions that return Status
// without this pr:
Status res = CallSomeFunc();
if (res != Status::success) {
  return res;
}

// with this pr:
RETURN_IF_ERROR(CallSomeFunc());
```

4. slightly refactored `index.h` to extract some duplicate codes into a method
5. in `diskann.cc` make `TryDiskANNCall` non-template and make its argument function have no return value, which is clearer.

This PR contains no feature/performance change.