### PR TITLE
Sync perform of HNSW/DiskANN

### DIFF
--- a/knowhere/index/vector_index/ConfAdapter.cpp
+++ b/knowhere/index/vector_index/ConfAdapter.cpp
@@ -39,7 +39,6 @@ static const int64_t HNSW_MIN_EFCONSTRUCTION = 8;
 static const int64_t HNSW_MAX_EFCONSTRUCTION = 512;
 static const int64_t HNSW_MIN_M = 4;
 static const int64_t HNSW_MAX_M = 64;
-static const int64_t HNSW_MAX_EF = 32768;
 
 static const std::vector<MetricType> default_metric_array{metric::L2, metric::IP};
 static const std::vector<MetricType> default_binary_metric_array{metric::HAMMING, metric::JACCARD, metric::TANIMOTO,
@@ -237,14 +236,7 @@ HNSWConfAdapter::CheckTrain(Config& cfg, const IndexMode mode) {
 
 bool
 HNSWConfAdapter::CheckSearch(Config& cfg, const IndexType type, const IndexMode mode) {
-    auto topk = GetMetaTopk(cfg);
-    if (topk < HNSW_MAX_EF) {
-        // normal case if topk is not large
-        CheckIntegerRange(cfg, indexparam::EF, GetMetaTopk(cfg), HNSW_MAX_EF);
-    } else {
-        // if topk is large
-        CheckIntegerRange(cfg, indexparam::EF, topk, topk * 2);
-    }
+    CheckIntegerRange(cfg, indexparam::EF, GetMetaTopk(cfg), std::numeric_limits<int64_t>::max());
     return ConfAdapter::CheckSearch(cfg, type, mode);
 }
 

--- a/knowhere/index/vector_index/IndexDiskANNConfig.h
+++ b/knowhere/index/vector_index/IndexDiskANNConfig.h
@@ -85,8 +85,9 @@ struct DiskANNPrepareConfig {
 struct DiskANNQueryConfig {
     uint64_t k;
     // A list of search_list sizes to perform searches with. Larger parameters will result in slower latencies, but
-    // higher accuracies. Must be at least the value of k.
-    uint32_t search_list_size = 128;
+    // higher accuracies. Must be at least the value of k. Default to 0, meaning Knowhere need to take care of the
+    // default value
+    uint32_t search_list_size = 0;
     // The beamwidth to be used for search. This is the maximum number of IO requests each query will issue per
     // iteration of search code. Larger beamwidth will result in fewer IO round-trips per query but might result in
     // slightly higher total number of IO requests to SSD per query. For the highest query throughput with a fixed SSD
@@ -125,5 +126,6 @@ struct DiskANNQueryByRangeConfig {
     Set(Config& config, const DiskANNQueryByRangeConfig& query_conf);
 };
 
-Config GenSanityCheckDiskANNConfig(const Config& build_config);
+Config
+GenSanityCheckDiskANNConfig(const Config& build_config);
 }  // namespace knowhere

--- a/knowhere/index/vector_index/IndexHNSW.cpp
+++ b/knowhere/index/vector_index/IndexHNSW.cpp
@@ -29,21 +29,11 @@
 #include "index/vector_index/helpers/RangeUtil.h"
 
 namespace knowhere {
+
 namespace {
-    inline int64_t
-    CheckAndGetEfValue(const Config& config) {
-        auto topk_val = GetMetaTopk(config);
-        if (CheckKeyInConfig(config, indexparam::EF)) {
-            auto ef_val = GetIndexParamEf(config);
-            if (ef_val < topk_val) {
-                KNOWHERE_THROW_MSG("ef is smaller than topk in hnsw.");
-            }
-            return ef_val;
-        } else {
-            return std::max(knowhere::DEFAULT_HNSW_EF, topk_val);
-        }
-    }
-}  // namespace
+static constexpr int64_t kDefaultEfDivider = 16;
+static constexpr int64_t kDefaultRangeSearchEf = 16;
+}
 
 BinarySet
 IndexHNSW::Serialize(const Config& config) {
@@ -267,7 +257,7 @@ IndexHNSW::QueryImpl(int64_t n, const float* xq, int64_t k, float* distances, in
         feder = std::make_unique<feder::hnsw::FederResult>();
     }
 
-    size_t ef = CheckAndGetEfValue(config);
+    size_t ef = GetIndexParamEf(config, k <= kDefaultEfDivider ? kDefaultEfDivider : k);
 
     hnswlib::SearchParam param{ef};
     bool transform = (index_->metric_type_ == 1);  // InnerProduct: 1
@@ -309,7 +299,8 @@ IndexHNSW::QueryByRangeImpl(int64_t n, const float* xq, float*& distances, int64
         feder = std::make_unique<feder::hnsw::FederResult>();
     }
 
-    size_t ef = CheckAndGetEfValue(config);
+    size_t ef = GetIndexParamEf(config, kDefaultRangeSearchEf);
+
     hnswlib::SearchParam param{ef};
 
     float radius = GetMetaRadius(config);

--- a/knowhere/index/vector_index/helpers/IndexParameter.h
+++ b/knowhere/index/vector_index/helpers/IndexParameter.h
@@ -108,6 +108,11 @@ SetValueToConfig(Config& cfg, const std::string& key, const T value) {
         return GetValueFromConfigWithDefaultValue<T>(cfg, key, value);    \
     }
 
+#define DEFINE_CONFIG_GETTER_WITH_CUSTOMIZED_DEFAULT_VALUE(func_name, key, T) \
+    inline T func_name(const Config& cfg, T value) {                               \
+        return GetValueFromConfigWithDefaultValue<T>(cfg, key, value);    \
+    }
+
 #define DEFINE_CONFIG_SETTER(func_name, key, T)    \
     inline void func_name(Config& cfg, T value) {  \
         SetValueToConfig<T>(cfg, key, (T)(value)); \
@@ -153,7 +158,6 @@ static const int64_t DEFAULT_PQ_M = 4;
 static const int64_t DEFAULT_PQ_NBITS = 8;
 static const int64_t DEFAULT_HNSW_EFCONSTRUCTION = 360;
 static const int64_t DEFAULT_HNSW_M = 30;
-static const int64_t DEFAULT_HNSW_EF = 16;
 
 DEFINE_CONFIG_GETTER_WITH_DEFAULT_VALUE(GetIndexParamNprobe, indexparam::NPROBE, DEFAULT_NPROBE, int64_t)
 DEFINE_CONFIG_SETTER(SetIndexParamNprobe, indexparam::NPROBE, int64_t)
@@ -176,7 +180,7 @@ DEFINE_CONFIG_SETTER(SetIndexParamEfConstruction, indexparam::EFCONSTRUCTION, in
 DEFINE_CONFIG_GETTER_WITH_DEFAULT_VALUE(GetIndexParamHNSWM, indexparam::HNSW_M, DEFAULT_HNSW_M, int64_t)
 DEFINE_CONFIG_SETTER(SetIndexParamHNSWM, indexparam::HNSW_M, int64_t)
 
-DEFINE_CONFIG_GETTER(GetIndexParamEf, indexparam::EF, int64_t)
+DEFINE_CONFIG_GETTER_WITH_CUSTOMIZED_DEFAULT_VALUE(GetIndexParamEf, indexparam::EF, int64_t)
 DEFINE_CONFIG_SETTER(SetIndexParamEf, indexparam::EF, int64_t)
 
 DEFINE_CONFIG_GETTER(GetIndexParamOverviewLevels, indexparam::OVERVIEW_LEVELS, int64_t)

--- a/unittest/test_diskann.cpp
+++ b/unittest/test_diskann.cpp
@@ -477,7 +477,7 @@ TEST_P(DiskANNTest, search_without_search_list_size) {
     cfg.clear();
     knowhere::DiskANNQueryConfig::Set(cfg, tmp_config);
     search_list_size = knowhere::DiskANNQueryConfig::Get(cfg).search_list_size;
-    EXPECT_EQ(search_list_size, 128);
+    EXPECT_EQ(search_list_size, 16);
 }
 
 TEST_P(DiskANNTest, knn_search_test) {


### PR DESCRIPTION
We need to sync the perform of Indexes in Knowhere:
1. When no specific parameter comes in, we use default but valid value. So no exception should be throw out in the case.
2. When a specific parameter comes in, we need to check its validation and throw exception once it is bad.
3. It is not acceptable to modify the parameter if user explicitly write it.

For HNSW:
We simple made the `ef` range to `k - max`, and default is `min(k, 16)`.
For DiskANN:
We did the same thing.