### PR TITLE
Sync HNSW ef behavior with knowhere-1.x

### DIFF
--- a/include/knowhere/config.h
+++ b/include/knowhere/config.h
@@ -475,6 +475,11 @@ class BaseConfig : public Config {
         }
         return omp_get_max_threads();
     }
+
+    virtual Status
+    CheckAndAdjustConfig() {
+        return Status::success;
+    }
 };
 }  // namespace knowhere
 

--- a/include/knowhere/index.h
+++ b/include/knowhere/index.h
@@ -169,6 +169,7 @@ class Index {
         KNOWHERE_CHECK_EXPECTED(Config::FormatAndCheck(*cfg, json_));
         LOG_KNOWHERE_DEBUG_ << "Search config dump: " << json_.dump();
         KNOWHERE_CHECK_EXPECTED(Config::Load(*cfg, json_, knowhere::SEARCH));
+        KNOWHERE_CHECK_EXPECTED(cfg->CheckAndAdjustConfig());
 
 #ifdef NOT_COMPILE_FOR_SWIG
         TimeRecorder rc("Search");

--- a/src/index/hnsw/hnsw.cc
+++ b/src/index/hnsw/hnsw.cc
@@ -113,11 +113,6 @@ class HnswIndexNode : public IndexNode {
 
         auto hnsw_cfg = static_cast<const HnswConfig&>(cfg);
         auto k = hnsw_cfg.k;
-        auto maxef = std::max(65536, hnsw_cfg.k * 2);
-        if (hnsw_cfg.ef < k || hnsw_cfg.ef > maxef) {
-            LOG_KNOWHERE_ERROR_ << "ef should be in range: [topk, max(65536, topk * 2)]";
-            return unexpected(Status::out_of_range_in_json);
-        }
 
         feder::hnsw::FederResultUniq feder_result;
         if (hnsw_cfg.trace_visit) {

--- a/src/index/hnsw/hnsw_config.h
+++ b/src/index/hnsw/hnsw_config.h
@@ -12,7 +12,12 @@
 #ifndef HNSW_CONFIG_H
 #define HNSW_CONFIG_H
 
+#include "knowhere/comp/index_param.h"
 #include "knowhere/config.h"
+
+// This is not a valid EF value for HNSW
+// This value is used to tell if HnswConfig.ef is coming from user or not
+const int64_t kDefaultHnswEfPlaceholder = -1;
 
 namespace knowhere {
 class HnswConfig : public BaseConfig {
@@ -30,7 +35,7 @@ class HnswConfig : public BaseConfig {
             .for_train();
         KNOWHERE_CONFIG_DECLARE_FIELD(ef)
             .description("hnsw ef")
-            .set_default(16)
+            .set_default(kDefaultHnswEfPlaceholder)
             .set_range(1, std::numeric_limits<CFG_INT>::max())
             .for_search()
             .for_range_search();
@@ -39,6 +44,27 @@ class HnswConfig : public BaseConfig {
             .set_default(3)
             .set_range(1, 5)
             .for_feder();
+    }
+
+    Status
+    CheckAndAdjustConfig() override {
+        auto& hnsw_cfg = static_cast<HnswConfig&>(*this);
+        auto maxef = std::max(65536, hnsw_cfg.k * 2);
+        if (hnsw_cfg.ef > maxef) {
+            LOG_KNOWHERE_ERROR_ << "ef should be in range: [topk, max(65536, topk * 2)]";
+            return Status::out_of_range_in_json;
+        }
+        if (hnsw_cfg.ef < hnsw_cfg.k) {
+            if (hnsw_cfg.ef == kDefaultHnswEfPlaceholder) {
+                // ef is set by default value, set ef to k
+                hnsw_cfg.ef = hnsw_cfg.k;
+            } else {
+                // ef is set by user
+                LOG_KNOWHERE_ERROR_ << "ef should be in range: [topk, max(65536, topk * 2)]";
+                return Status::out_of_range_in_json;
+            }
+        }
+        return Status::success;
     }
 };
 


### PR DESCRIPTION
ef is set:
  ef >= topk ==> pass
  ef < topk   ==> err out

ef not set:
  set ef to topk