### PR TITLE
Merge Train/Add to Build

### DIFF
--- a/include/knowhere/index_node.h
+++ b/include/knowhere/index_node.h
@@ -24,7 +24,10 @@ namespace knowhere {
 class IndexNode : public Object {
  public:
     virtual Status
-    Build(const DataSet& dataset, const Config& cfg) = 0;
+    Build(const DataSet& dataset, const Config& cfg) {
+        RETURN_IF_ERROR(Train(dataset, cfg));
+        return Add(dataset, cfg);
+    }
 
     virtual Status
     Train(const DataSet& dataset, const Config& cfg) = 0;

--- a/include/knowhere/index_node_thread_pool_wrapper.h
+++ b/include/knowhere/index_node_thread_pool_wrapper.h
@@ -28,11 +28,6 @@ class IndexNodeThreadPoolWrapper : public IndexNode {
     }
 
     Status
-    Build(const DataSet& dataset, const Config& cfg) {
-        return index_node_->Build(dataset, cfg);
-    }
-
-    Status
     Train(const DataSet& dataset, const Config& cfg) {
         return index_node_->Train(dataset, cfg);
     }

--- a/src/index/cagra/cagra.cu
+++ b/src/index/cagra/cagra.cu
@@ -36,14 +36,6 @@ class CagraIndexNode : public IndexNode {
     }
 
     virtual Status
-    Build(const DataSet& dataset, const Config& cfg) override {
-        auto err = Train(dataset, cfg);
-        if (err != Status::success)
-            return err;
-        return Status::success;
-    }
-
-    virtual Status
     Train(const DataSet& dataset, const Config& cfg) override {
         auto cagra_cfg = static_cast<const knowhere::CagraConfig&>(cfg);
         if (gpu_index_) {

--- a/src/index/diskann/diskann.cc
+++ b/src/index/diskann/diskann.cc
@@ -43,17 +43,17 @@ class DiskANNIndexNode : public IndexNode {
     }
 
     Status
-    Build(const DataSet& dataset, const Config& cfg) override {
-        return Add(dataset, cfg);
-    }
+    Build(const DataSet& dataset, const Config& cfg) override;
 
     Status
     Train(const DataSet& dataset, const Config& cfg) override {
-        return Status::success;
+        return Status::not_implemented;
     }
 
     Status
-    Add(const DataSet& dataset, const Config& cfg) override;
+    Add(const DataSet& dataset, const Config& cfg) override {
+        return Status::not_implemented;
+    }
 
     expected<DataSetPtr>
     Search(const DataSet& dataset, const Config& cfg, const BitsetView& bitset) const override;
@@ -250,7 +250,7 @@ CheckMetric(const std::string& diskann_metric) {
 
 template <typename T>
 Status
-DiskANNIndexNode<T>::Add(const DataSet& dataset, const Config& cfg) {
+DiskANNIndexNode<T>::Build(const DataSet& dataset, const Config& cfg) {
     assert(file_manager_ != nullptr);
     std::lock_guard<std::mutex> lock(preparation_lock_);
     auto build_conf = static_cast<const DiskANNConfig&>(cfg);

--- a/src/index/flat/flat.cc
+++ b/src/index/flat/flat.cc
@@ -33,12 +33,6 @@ class FlatIndexNode : public IndexNode {
     }
 
     Status
-    Build(const DataSet& dataset, const Config& cfg) override {
-        RETURN_IF_ERROR(Train(dataset, cfg));
-        return Add(dataset, cfg);
-    }
-
-    Status
     Train(const DataSet& dataset, const Config& cfg) override {
         const FlatConfig& f_cfg = static_cast<const FlatConfig&>(cfg);
 

--- a/src/index/gpu/flat_gpu/flat_gpu.cc
+++ b/src/index/gpu/flat_gpu/flat_gpu.cc
@@ -27,12 +27,6 @@ class GpuFlatIndexNode : public IndexNode {
     }
 
     virtual Status
-    Build(const DataSet& dataset, const Config& cfg) override {
-        RETURN_IF_ERROR(Train(dataset, cfg));
-        return Add(dataset, cfg);
-    }
-
-    virtual Status
     Train(const DataSet& dataset, const Config& cfg) override {
         const GpuFlatConfig& f_cfg = static_cast<const GpuFlatConfig&>(cfg);
         auto metric = Str2FaissMetricType(f_cfg.metric_type);

--- a/src/index/gpu/ivf_gpu/ivf_gpu.cc
+++ b/src/index/gpu/ivf_gpu/ivf_gpu.cc
@@ -55,12 +55,6 @@ class GpuIvfIndexNode : public IndexNode {
     }
 
     virtual Status
-    Build(const DataSet& dataset, const Config& cfg) override {
-        RETURN_IF_ERROR(Train(dataset, cfg));
-        return Add(dataset, cfg);
-    }
-
-    virtual Status
     Train(const DataSet& dataset, const Config& cfg) override {
         if (index_ && index_->is_trained) {
             LOG_KNOWHERE_WARNING_ << "index is already trained";

--- a/src/index/hnsw/hnsw.cc
+++ b/src/index/hnsw/hnsw.cc
@@ -37,12 +37,6 @@ class HnswIndexNode : public IndexNode {
     }
 
     Status
-    Build(const DataSet& dataset, const Config& cfg) override {
-        RETURN_IF_ERROR(Train(dataset, cfg));
-        return Add(dataset, cfg);
-    }
-
-    Status
     Train(const DataSet& dataset, const Config& cfg) override {
         auto rows = dataset.GetRows();
         auto dim = dataset.GetDim();

--- a/src/index/ivf/ivf.cc
+++ b/src/index/ivf/ivf.cc
@@ -50,8 +50,6 @@ class IvfIndexNode : public IndexNode {
         pool_ = ThreadPool::GetGlobalThreadPool();
     }
     Status
-    Build(const DataSet& dataset, const Config& cfg) override;
-    Status
     Train(const DataSet& dataset, const Config& cfg) override;
     Status
     Add(const DataSet& dataset, const Config& cfg) override;
@@ -190,16 +188,6 @@ class IvfIndexNode : public IndexNode {
 }  // namespace knowhere
 
 namespace knowhere {
-
-template <typename T>
-Status
-IvfIndexNode<T>::Build(const DataSet& dataset, const Config& cfg) {
-    const BaseConfig& base_cfg = static_cast<const IvfConfig&>(cfg);
-    auto build_thread_num = base_cfg.get_build_thread_num();
-    ThreadPool::ScopedOmpSetter setter(build_thread_num);
-    RETURN_IF_ERROR(Train(dataset, cfg));
-    return Add(dataset, cfg);
-}
 
 inline int64_t
 MatchNlist(int64_t size, int64_t nlist) {

--- a/src/index/ivf_raft/ivf_raft.cuh
+++ b/src/index/ivf_raft/ivf_raft.cuh
@@ -256,12 +256,6 @@ class RaftIvfIndexNode : public IndexNode {
     }
 
     virtual Status
-    Build(const DataSet& dataset, const Config& cfg) override {
-        RETURN_IF_ERROR(Train(dataset, cfg));
-        return Add(dataset, cfg);
-    }
-
-    virtual Status
     Train(const DataSet& dataset, const Config& cfg) override {
         auto ivf_raft_cfg = static_cast<const typename KnowhereConfigType<T>::Type&>(cfg);
         if (gpu_index_) {


### PR DESCRIPTION
Knowhere has `Build`, `Train` and `Add` APIs, their semantic should be:
`Build`: build a index in a batch.
`Train`: train the index w/o adding data
`Add`: add data to indexes.

For DiskANN, we should not support `Train` & `Add` but only `Build`