### PR TITLE
Pipeline GetVectorByIds and Not Use ThreadPool

### DIFF
--- a/thirdparty/DiskANN/include/diskann/aio_context_pool.h
+++ b/thirdparty/DiskANN/include/diskann/aio_context_pool.h
@@ -14,7 +14,7 @@ namespace {
   size_t           global_aio_max_events = 0;
   std::mutex       global_aio_pool_mut;
   constexpr size_t default_max_nr = 65536;
-  constexpr size_t default_max_events = 32;
+  constexpr size_t default_max_events = 256; // sync this with diskann MAX_N_SECTOR_READS
   const size_t     default_pool_size =
       std::min(size_t(std::thread::hardware_concurrency() * 10),
                default_max_nr / default_max_events);

--- a/thirdparty/DiskANN/include/diskann/aligned_file_reader.h
+++ b/thirdparty/DiskANN/include/diskann/aligned_file_reader.h
@@ -95,4 +95,8 @@ class AlignedFileReader {
   // NOTE :: blocking call
   virtual void read(std::vector<AlignedRead>& read_reqs, IOContext& ctx,
                     bool async = false) = 0;
+
+  // async reads
+  virtual void get_submitted_req(io_context_t &ctx, size_t n_ops) = 0;
+  virtual void submit_req( io_context_t &ctx, std::vector<AlignedRead> &read_reqs) = 0;
 };

--- a/thirdparty/DiskANN/include/diskann/linux_aligned_file_reader.h
+++ b/thirdparty/DiskANN/include/diskann/linux_aligned_file_reader.h
@@ -35,6 +35,10 @@ class LinuxAlignedFileReader : public AlignedFileReader {
   // NOTE :: blocking call
   void read(std::vector<AlignedRead> &read_reqs, IOContext &ctx,
             bool async = false);
+
+  // async reads
+  void get_submitted_req (io_context_t &ctx, size_t n_ops) override;
+  void submit_req(io_context_t &ctx, std::vector<AlignedRead> &read_reqs);
 };
 
 #endif

--- a/thirdparty/DiskANN/include/diskann/pq_flash_index.h
+++ b/thirdparty/DiskANN/include/diskann/pq_flash_index.h
@@ -28,7 +28,7 @@
 
 #define MAX_GRAPH_DEGREE 512
 #define SECTOR_LEN (_u64) 4096
-#define MAX_N_SECTOR_READS 128
+#define MAX_N_SECTOR_READS 256
 
 #define FULL_PRECISION_REORDER_MULTIPLIER 3
 
@@ -111,10 +111,8 @@ namespace diskann {
         const float l_k_ratio, knowhere::BitsetView bitset_view = nullptr,
         QueryStats *stats = nullptr);
 
-
-    DISKANN_DLLEXPORT void get_vector_by_ids(const int64_t *ids,
-                                             const int64_t n,
-                                                T *output_data);
+    DISKANN_DLLEXPORT void get_vector_by_ids(
+        const int64_t *ids, const int64_t n, T *const output_data);
 
     std::shared_ptr<AlignedFileReader> reader;
 
@@ -168,7 +166,7 @@ namespace diskann {
 
     // Assign the index of ids to its corresponding sector and if it is in
     // cache, write to the output_data
-    std::unordered_map<_u64, std::vector<_u64>>
+    DISKANN_DLLEXPORT std::unordered_map<_u64, std::vector<_u64>>
     get_sectors_layout_and_write_data_from_cache(const int64_t *ids, int64_t n,
                                                  T *output_data);
 

--- a/thirdparty/DiskANN/src/pq_flash_index.cpp
+++ b/thirdparty/DiskANN/src/pq_flash_index.cpp
@@ -1533,29 +1533,25 @@ namespace diskann {
   }
 
   template<typename T>
-  void PQFlashIndex<T>::get_vector_by_ids(const int64_t *ids, const int64_t n, T *output_data) {
-    size_t batch_size = kReadBatchSize;
-    if (long_node) {
-      auto min_size = kReadBatchSize / nsectors_per_node;
-      batch_size = (min_size == 0) ? MAX_N_SECTOR_READS : min_size;
-      if (0 == batch_size) {
-        LOG(ERROR) << "Vector too large, exceeding max number of sector reads";
-        return ;
-      }
+  void PQFlashIndex<T>::get_vector_by_ids(const int64_t *ids, const int64_t n,
+                                          T *output_data) {
+    auto sectors_to_visit =
+        get_sectors_layout_and_write_data_from_cache(ids, n, output_data);
+    if (0 == sectors_to_visit.size()) {
+      return;
     }
+
     ThreadData<T> data = this->thread_data.pop();
     while (data.scratch.sector_scratch == nullptr) {
       this->thread_data.wait_for_push_notify();
       data = this->thread_data.pop();
     }
+
+    const size_t batch_size = std::min(MAX_N_SECTOR_READS / 2UL, sectors_to_visit.size());
+    const size_t half_buf_idx = MAX_N_SECTOR_READS / 2 * read_len_for_node;
     char *sector_scratch = data.scratch.sector_scratch;
     std::vector<AlignedRead> frontier_read_reqs;
     frontier_read_reqs.reserve(batch_size);
-
-    auto sectors_to_visit = get_sectors_layout_and_write_data_from_cache(ids, n, output_data);
-    if (sectors_to_visit.size() == 0) {
-      return;
-    }
 
     std::vector<_u64> sector_offsets;
     sector_offsets.reserve(sectors_to_visit.size());
@@ -1566,28 +1562,46 @@ namespace diskann {
     auto ctx = this->reader->get_ctx();
     const auto sector_num = sector_offsets.size();
     const _u64 num_blocks = DIV_ROUND_UP(sector_num, batch_size);
+    std::vector<AlignedRead> last_reqs;
+    bool rotate = false;
+
     for (_u64 i = 0; i < num_blocks; ++i) {
       _u64 start_idx = i * batch_size;
       _u64 idx_len = std::min(batch_size, sector_num - start_idx);
+      last_reqs = frontier_read_reqs;
       frontier_read_reqs.clear();
       for (_u64 j = 0; j < idx_len; ++j) {
-        char *sector_buf = sector_scratch + j * read_len_for_node;
+        char *sector_buf =
+            sector_scratch + rotate * half_buf_idx + j * read_len_for_node;
         frontier_read_reqs.emplace_back(sector_offsets[start_idx + j], read_len_for_node,
                                     sector_buf);
       }
-      reader->read(frontier_read_reqs, ctx);
-      for (const auto& req : frontier_read_reqs) {
+      rotate ^= 0x1;
+      reader->submit_req(ctx, frontier_read_reqs);
+      for (const auto& req : last_reqs) {
         auto offset = req.offset;
         char* sector_buf = static_cast<char*>(req.buf);
-        for (auto idx : sectors_to_visit[offset]) {
+        for (auto idx : sectors_to_visit.at(offset)) {
           char* node_buf = get_offset_to_node(sector_buf, ids[idx]);
           copy_vec_base_data(output_data, idx, node_buf);
         }
       }
+      reader->get_submitted_req(ctx, frontier_read_reqs.size());
     }
+
+    // if any remaining
+    for (const auto& req : frontier_read_reqs) {
+      auto offset = req.offset;
+      char* sector_buf = static_cast<char*>(req.buf);
+      for (auto idx : sectors_to_visit.at(offset)) {
+        char* node_buf = get_offset_to_node(sector_buf, ids[idx]);
+        copy_vec_base_data(output_data, idx, node_buf);
+      }
+    }
+
+    this->reader->put_ctx(ctx);
     this->thread_data.push(data);
     this->thread_data.push_notify_all();
-    this->reader->put_ctx(ctx);
   }
 
   template<typename T>


### PR DESCRIPTION
issue: #919 

Improve DiskANN `GetVectorByIds` further by pipeline if the number of requested Ids in a call exceeds buffer size.
The concurrency is totally controlled by the outside, e.g. Milvus. In Milvus, the maximum concurrency is the same as `cpu_num`.

### Conclusion
Without using the thread pool, a pipeline to cover the cost of copying and combining multiple I/O events in one request has a clear advantage over previous implementations.

Comparing these two pipelines:

- P1: submit 1->copy out 0->get 1->submit 2->copy out 1->get 2
- P2: submit 1->get 0->copy out 0->submit2->get 1->copy out1 (suggested by @liliu-z)


P1 uses only one context and performs better when the number of IDs is small. It might be the context buffer has a better locality.
P2 performs better when the number of IDs is large since there is one more operation between two submits. However, it uses two contexts to submit I/O requests, the number of maximum I/O events is limited in a Linux system, defaulting to `65536`. Thus, the number of contexts is limited, under the current implementation, the maximum number of contexts is `256`. If we go down P2, then using the thread above `128` will be a concern.


### Experiments and Results
**Single Thread**
2G **256 Dim**

50 random ids, 100k round

  | Avg (us) | Min (us) | Max (us)
---|---|---|---
I/O Request per thread in Pool | 429 | 181 | 5859
Batch + Pool | 339 | 309 | 1413
No Pool, No Pipeline   in this case | 275 :white_check_mark: | 257 | 628
No Pool, No Pipeline, Two   Contexts | 311 | 262 | 683

1000 random   ids, 10k round
  | Avg (us) | Min (us) | Max (us)
---|---|---|---
I/O Request per thread in Pool | 2910 | 2649 | 5718
Batch + Pool | 5344 | 4779 | 6789
No Pool, Pipeline | 2338 | 2211 | 3454
No Pool, Pipeline, Two   Contexts | 2069 :white_check_mark: | 1797 | 2904

10000 random   ids, 10k round
  | Avg (us) | Min (us) | Max (us)
---|---|---|---
I/O Request per thread in Pool | 26314 | 24655 | 43706
Batch + Pool | 47974 | 46950 | 81613
No Pool, Pipeline | 20106 | 19457 | 26295
No Pool, Pipeline, Two   Contexts | 17349 :white_check_mark: | 16577 | 22493

2G **1536 Dim**
50 random   ids, 100k round
  | Avg (us) | Min (us) | Max (us)
---|---|---|---
No Pool, No Pipeline in this   case | 682 :white_check_mark: | 570 | 1944
No Pool, No Pipeline, Two   Contexts | 684 | 563 | 1731


1000 random   ids, 5k round 
  | Avg (us) | Min (us) | Max (us)
---|---|---|---
No Pool, Pipeline | 13709 | 12581 | 14933
No Pool, Pipeline, Two   Contexts | 11705 :white_check_mark:  | 10758 | 12186

**12 Threads**
2G **256 Dim**
50 random   ids, 100k round

  | Avg (us) | Min (us) | Max (us)
---|---|---|---
No Pool, No Pipeline in this   case | 940 :white_check_mark: | 246 | 1281
No Pool, No Pipeline, Two   Contexts | 1356 | 471 | 1809

1000 random   ids, 10k round
  | Avg (us) | Min (us) | Max (us)
---|---|---|---
No Pool, Pipeline | 23457 | 2984 | 39783
No Pool, Pipeline, Two   Contexts | 21036 :white_check_mark: | 2066 | 67267

10000 random   ids, 10k round
  | Avg (us) | Min (us) | Max (us)
---|---|---|---
No Pool, Pipeline | 188423 :white_check_mark: | 21740 | 248392
No Pool, Pipeline, Two   Contexts | 200037 | 31967 | 461448

2G **1536 Dim**
50 random   ids, 100k round
  | Avg (us) | Min (us) | Max (us)
---|---|---|---
No Pool, No Pipeline in this   case | 5501 :white_check_mark: | 1435 | 9465
No Pool, No Pipeline, Two   Contexts | 5520 | 1226 | 7979

1000 random   ids, 5k round 
  | Avg (us) | Min (us) | Max (us)
---|---|---|---
No Pool, Pipeline | 137837 | 13738 | 265231
No Pool, Pipeline, Two   Contexts | 133933 :white_check_mark: | 11650 | 316493
