### PR TITLE
Sync param check for DiskANN and HNSW

### DIFF
--- a/include/knowhere/config.h
+++ b/include/knowhere/config.h
@@ -82,6 +82,7 @@ struct Entry<CFG_STRING> {
     uint32_t type;
     std::optional<CFG_STRING::value_type> default_val;
     std::optional<std::string> desc;
+    bool allow_empty_without_default = false;
 };
 
 template <>
@@ -106,6 +107,7 @@ struct Entry<CFG_FLOAT> {
     uint32_t type;
     std::optional<std::pair<CFG_FLOAT::value_type, CFG_FLOAT::value_type>> range;
     std::optional<std::string> desc;
+    bool allow_empty_without_default = false;
 };
 
 template <>
@@ -130,6 +132,7 @@ struct Entry<CFG_INT> {
     uint32_t type;
     std::optional<std::pair<CFG_INT::value_type, CFG_INT::value_type>> range;
     std::optional<std::string> desc;
+    bool allow_empty_without_default = false;
 };
 
 template <>
@@ -152,6 +155,7 @@ struct Entry<CFG_LIST> {
     std::optional<CFG_LIST::value_type> default_val;
     uint32_t type;
     std::optional<std::string> desc;
+    bool allow_empty_without_default = false;
 };
 
 template <>
@@ -174,6 +178,7 @@ struct Entry<CFG_BOOL> {
     std::optional<CFG_BOOL::value_type> default_val;
     uint32_t type;
     std::optional<std::string> desc;
+    bool allow_empty_without_default = false;
 };
 
 template <typename T>
@@ -191,6 +196,12 @@ class EntryAccess {
     EntryAccess&
     set_range(typename T::value_type a, typename T::value_type b) {
         entry->range = std::make_pair(a, b);
+        return *this;
+    }
+
+    EntryAccess&
+    allow_empty_without_default() {
+        entry->allow_empty_without_default = true;
         return *this;
     }
 
@@ -263,6 +274,9 @@ class Config {
                     continue;
                 }
                 if (json.find(it.first) == json.end() && !ptr->default_val.has_value()) {
+                    if (ptr->allow_empty_without_default) {
+                        continue;
+                    }
                     LOG_KNOWHERE_ERROR_ << "Invalid param [" << it.first << "] in json.";
                     return Status::invalid_param_in_json;
                 }
@@ -298,6 +312,9 @@ class Config {
                     continue;
                 }
                 if (json.find(it.first) == json.end() && !ptr->default_val.has_value()) {
+                    if (ptr->allow_empty_without_default) {
+                        continue;
+                    }
                     LOG_KNOWHERE_ERROR_ << "Invalid param [" << it.first << "] in json.";
                     return Status::invalid_param_in_json;
                 }
@@ -333,6 +350,9 @@ class Config {
                     continue;
                 }
                 if (json.find(it.first) == json.end() && !ptr->default_val.has_value()) {
+                    if (ptr->allow_empty_without_default) {
+                        continue;
+                    }
                     LOG_KNOWHERE_ERROR_ << "Invalid param [" << it.first << "] in json.";
                     return Status::invalid_param_in_json;
                 }
@@ -352,6 +372,9 @@ class Config {
                     continue;
                 }
                 if (json.find(it.first) == json.end() && !ptr->default_val.has_value()) {
+                    if (ptr->allow_empty_without_default) {
+                        continue;
+                    }
                     LOG_KNOWHERE_ERROR_ << "Invalid param [" << it.first << "] in json.";
                     return Status::invalid_param_in_json;
                 }
@@ -374,6 +397,9 @@ class Config {
                     continue;
                 }
                 if (json.find(it.first) == json.end() && !ptr->default_val.has_value()) {
+                    if (ptr->allow_empty_without_default) {
+                        continue;
+                    }
                     LOG_KNOWHERE_ERROR_ << "Invalid param [" << it.first << "] in json.";
                     return Status::invalid_param_in_json;
                 }
@@ -456,12 +482,17 @@ class BaseConfig : public Config {
     }
 
     virtual Status
-    CheckAndAdjustConfigForSearch() {
+    CheckAndAdjustForSearch() {
         return Status::success;
     }
 
     virtual Status
-    CheckAndAdjustConfigForRangeSearch() {
+    CheckAndAdjustForRangeSearch() {
+        return Status::success;
+    }
+
+    virtual inline Status
+    CheckAndAdjustForBuild() {
         return Status::success;
     }
 };

--- a/include/knowhere/index.h
+++ b/include/knowhere/index.h
@@ -122,6 +122,7 @@ class Index {
     Build(const DataSet& dataset, const Json& json) {
         auto cfg = this->node->CreateConfig();
         RETURN_IF_ERROR(LoadConfig(cfg.get(), json, knowhere::TRAIN, "Build"));
+        RETURN_IF_ERROR(cfg->CheckAndAdjustForBuild());
 
 #ifdef NOT_COMPILE_FOR_SWIG
         TimeRecorder rc("Build");
@@ -153,7 +154,7 @@ class Index {
     Search(const DataSet& dataset, const Json& json, const BitsetView& bitset) const {
         auto cfg = this->node->CreateConfig();
         RETURN_IF_ERROR(LoadConfig(cfg.get(), json, knowhere::SEARCH, "Search"));
-        RETURN_IF_ERROR(cfg->CheckAndAdjustConfigForSearch());
+        RETURN_IF_ERROR(cfg->CheckAndAdjustForSearch());
 
 #ifdef NOT_COMPILE_FOR_SWIG
         TimeRecorder rc("Search");
@@ -171,7 +172,7 @@ class Index {
     RangeSearch(const DataSet& dataset, const Json& json, const BitsetView& bitset) const {
         auto cfg = this->node->CreateConfig();
         RETURN_IF_ERROR(LoadConfig(cfg.get(), json, knowhere::RANGE_SEARCH, "RangeSearch"));
-        RETURN_IF_ERROR(cfg->CheckAndAdjustConfigForRangeSearch());
+        RETURN_IF_ERROR(cfg->CheckAndAdjustForRangeSearch());
 
 #ifdef NOT_COMPILE_FOR_SWIG
         TimeRecorder rc("Range Search");

--- a/tests/ut/test_diskann.cc
+++ b/tests/ut/test_diskann.cc
@@ -122,7 +122,7 @@ TEST_CASE("Invalid diskann params test", "[diskann]") {
             test_json["search_list_size"] = 1;
             auto res = diskann.Search(*query_ds, test_json, nullptr);
             REQUIRE_FALSE(res.has_value());
-            REQUIRE(res.error() == knowhere::Status::invalid_args);
+            REQUIRE(res.error() == knowhere::Status::out_of_range_in_json);
         }
         // min_k > max_k
         {


### PR DESCRIPTION
This PR is to sync how HNSW&DiskANN will perform with empty config with Knowhere 1.x:

The rule is:
1. If `ef` exists, we need to ensure `ef` >= `k`.
2. If `ef` not exists, let `ef` = max(16, `k`).
